### PR TITLE
Add test dependency on Statistics to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,9 @@ julia = "1"
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"
 JuliennedArrays = "5cadff95-7770-533d-a838-a1bf817ee6e0"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Einsum", "JuliennedArrays", "StaticArrays", "Strided"]
+test = ["Test", "Einsum", "JuliennedArrays", "StaticArrays", "Statistics", "Strided"]


### PR DESCRIPTION
Noticed while checking for package testing regressions for the upcoming Julia 1.2 release