### PR TITLE
Simplify glue using LazyStack

### DIFF
--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -9,7 +9,7 @@ end
 
 export @cast, @reduce, @matmul, @pretty
 
-using MacroTools, StaticArrays, Compat
+using MacroTools, StaticArrays, LazyStack, Compat
 using LinearAlgebra, Random
 
 include("macro.jl")

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -305,7 +305,7 @@ function standardise(ex, store::NamedTuple, call::CallInfo; LHS=false)
             ijk = newijk
             A = :( view($A, $(beecolon...)) )
         else
-            error("can't handle this indexing yet, sorry")
+            throw(MacroError("can't handle this indexing yet, sorry", call))
             # LHS && error("can't do this indexing on LHS sorry")
             # A = maybepush(A, store, :preget)
             # target = guesstarget(??)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -432,32 +432,17 @@ function standardglue(ex, target, store::NamedTuple, call::CallInfo)
     checknorepeats(vcat(inner, outer), call,
         " in gluing " * string(:([$(outer...)])) * string(:([$(inner...)])))
 
-    # Now we glue, always in A[k,l][i,j] -> B[i,j,k,l] order to start with:
+    # Now we glue, always in A[k,l][i,j] -> B[i,j,k,l] order:
     ijk = vcat(inner, outer)
-    code = Tuple(Any[ i in inner ? (:) : (*) for i in ijk ])
 
     if static
         AB = :( TensorCast.static_glue($B) )
         pop!(call.flags, :collected, :ok)
-    elseif :glue in call.flags
-        # allow maximum freedom? TODO
-        code, ijk = gluereorder(code, ijk, target)
-
-        AB = :( TensorCast.copy_glue($B, $code) )
-    elseif :cat in call.flags
-        AB = :( TensorCast.cat_glue($B, $code) )
-        push!(call.flags, :collected)
     elseif :lazy in call.flags
-        AB = :( TensorCast.lazy_glue($B, $code) )
+        AB = :( TensorCast.stack($B) )
         pop!(call.flags, :collected, :ok)
     else
-        # allow a little freedom?
-        if code == (*,:) && ijk == reverse(target)
-            code = (:,*)
-            ijk = target
-        end
-
-        AB = :( TensorCast.red_glue($B, $code) )
+        AB = :( TensorCast.LazyStack.stack_iter($B) )
         push!(call.flags, :collected)
     end
 

--- a/src/slice.jl
+++ b/src/slice.jl
@@ -10,16 +10,8 @@ or `A[:,i,:]` with `i=1:size(A,2)`.
 """
 function sliceview(A::AbstractArray{T,N}, code::Tuple) where {T,N}
     N == length(code) || throw(ArgumentError("wrong code length"))
-    if code == (:,*)
-        collect(eachcol(A))
-    elseif code == (*,:)
-        collect(eachrow(A))
-    elseif count(isequal(*), code) == 1
-        collect(eachslice(A, dims = findfirst(isequal(*), code)))
-    else
-        iter = Iterators.product(ntuple(d -> (code[d]==*) ? axes(A,d) : Ref(:), Val(N))...)
-        [ view(A, i...) for i in iter ]
-    end
+    iter = Iterators.product(ntuple(d -> (code[d]==*) ? axes(A,d) : Ref(:), Val(N))...)
+    [ view(A, i...) for i in iter ]
 end
 
 @doc @doc(sliceview)
@@ -33,79 +25,10 @@ sliceview(A::AbstractArray{T,N}) where {T,N} = sliceview(A, ntuple(i-> i==N ? (*
 slicecopy(A::AbstractArray{T,N}) where {T,N} = slicecopy(A, ntuple(i-> i==N ? (*) : (:), N))
 
 """
-    glue!(B, A, code)
-    copy_glue(A, code) = glue!(Array{T}(...), A, code)
+    copy_glue(A, code)
 
-Copy the contents of an array of arrays into one larger array,
-un-doing `sliceview` / `slicecopy` with the same `code`.
-This function can handle arbitrary codes.
-(Also called `stack` or `align` elsewhere.)
-
-    cat_glue(A, code)
-    red_glue(A, code)
-
-The same result, but calling either things like `hcat(A...)`
-or things like `reduce(hcat, A)`.
-The code must be sorted like `(:,:,:,*,*)`, except that `(*,:)` is allowed.
-
-    glue(A)
-    glue(A, code)
-
-If `code` is omitted, the default is like `(:,:,*,*)`
-with `ndims(first(A))` colons first, then `ndims(A)` stars.
-If the inner arrays are `StaticArray`s (and the code is sorted) then it calls `static_glue`.
-Otherwise it will call `red_glue`, unless code is unsuitable for that, in which case `copy_glue`.
+This is the inverse of `sliceview`, kept around only for ZygoteRules...
 """
-function glue(A::AbstractArray{<:AbstractArray{T,IN},ON}, code::Tuple=defaultcode(IN,ON)) where {T,IN,ON}
-    if iscodesorted(code) || code == (*,:)
-        red_glue(A, code)
-    else
-        copy_glue(A, code)
-    end
-end
-
-glue(A::AbstractArray{<:Tuple,ON}, code::Tuple=defaultcode(1,ON)) where {ON} = copy_glue(A, code)
-
-glue(A::AbstractArray{<:Number,ON}, code::Tuple=defaultcode(0,ON)) where {ON} = A
-
-defaultcode(IN::Int, ON::Int) = ntuple(d-> d<=IN ? (:) : (*), IN+ON)
-
-@doc @doc(glue)
-@inline function red_glue(A::AbstractArray{IT,N}, code::Tuple) where {IT,N}
-    gluecodecheck(A, code)
-    if code == (:,*)
-        reduce(hcat, A) # this is fast, specially optimised
-    elseif code == (*,:)
-        reduce(vcat, PermuteDims.(A))
-    elseif code == (:,:,*)
-        mat = reduce(hcat, A)
-        reshape(mat, gluedsize(A, code))
-    elseif iscodesorted(code)
-        mat = reduce(hcat, vec(vec.(A)))
-        reshape(mat, gluedsize(A, code))
-    else
-        throw(ArgumentError("can't glue code = $code with reduce(cat...)"))
-    end
-end
-
-@doc @doc(glue)
-@inline function cat_glue(A::AbstractArray{IT,N}, code::Tuple) where {IT,N}
-    gluecodecheck(A, code)
-    if code == (:,*)
-        hcat(A...)
-    elseif code == (*,:)
-        vcat(PermuteDims.(A)...)
-    elseif count(isequal(*), code) == 1 && code[end] == (*)
-        cat(A...; dims = length(code))
-    elseif iscodesorted(code)
-        flat = cat(vec(A)...; dims = length(code)-ndims(A)+1)
-        reshape(flat, gluedsize(A, code))
-    else
-        throw(ArgumentError("can't glue code = $code with cat(A...)"))
-    end
-end
-
-@doc @doc(glue)
 @inline function copy_glue(A::AbstractArray{IT,N}, code::Tuple) where {IT,N}
     gluecodecheck(A, code)
     B = Array{eltype(first(A))}(undef, gluedsize(A, code))
@@ -153,19 +76,6 @@ end
     n
 end
 
-@generated function iscodesorted(code::Tuple) # true if all colons before all stars
-    colons = true
-    sorted = true
-    for s in code.parameters
-        if s != Colon && colons # then we're at transition, change flag
-            colons = false
-        elseif s == Colon && !colons # then a : is following a *
-            sorted = false
-        end
-    end
-    sorted
-end
-
 @generated function gluedsize(A::AbstractArray{IT, N}, code::Tuple) where {IT, N}
     list = Any[]
     dout = 1
@@ -185,29 +95,12 @@ end
 _ndims(A) = ndims(A)
 _ndims(A::Tuple) = 1
 
-using LazyStack
-
-@inline function lazy_glue(A::AbstractArray{IT,N}, code::Tuple) where {IT,N}
-    gluecodecheck(A, code)
-    if code == (*,:)
-        PermuteDims(stack(A))
-    elseif iscodesorted(code)
-        stack(A)
-    else
-        error("can't glue code = $code with LazyStack")
-    end
-end
-
 using ZygoteRules # TODO add tests?
 
 # Rules moved from SliceView.jl
 
 @adjoint sliceview(A::AbstractArray, code::Tuple) =
-    sliceview(A, code), Δ -> (glue(Δ, code), nothing)
-
-@adjoint red_glue(A::AbstractArray, code::Tuple) =
-    red_glue(A, code), Δ -> (sliceview(Δ, code), nothing)
+    sliceview(A, code), Δ -> (copy_glue(Δ, code), nothing)
 
 @adjoint copy_glue(A::AbstractArray, code::Tuple) =
     copy_glue(A, code), Δ -> (sliceview(Δ, code), nothing)
-

--- a/src/static.jl
+++ b/src/static.jl
@@ -22,6 +22,12 @@ or call `static_slice(A, sizes, false)` to omit the reshape.
     end
 end
 
+function static_slice(A::AbstractArray, code::Tuple, finalshape::Bool=true)
+    iscodesorted(code) || error("expected to make slices of left-most dimensions")
+    tup = ntuple(d -> size(A,d), countcolons(code))
+    static_slice(A, Size(tup), finalshape)
+end
+
 """
     static_glue(A)
 

--- a/src/warm.jl
+++ b/src/warm.jl
@@ -13,11 +13,11 @@ pretty(:(  (B[j]+ C[k])[i] ))
 pretty(@macroexpand @cast A[i,j] := B[j,i] + 1 )
 
 # time julia -e 'using TensorCast; TensorCast.sliceview(rand(3,3), (*,:))'
-# 4.6 sec without, 4.5 sec with! 
+# 4.6 sec without, 4.5 sec with!
 
 _A = collect(reshape(1:9,3,3))
-red_glue(sliceview(_A, (*,:)), (*,:))
-red_glue(sliceview(_A, (:,*)), (:,*))
+# red_glue(sliceview(_A, (*,:)), (*,:))
+# red_glue(sliceview(_A, (:,*)), (:,*))
 orient(_A, (*,:,:))
 orient(_A, (*,*,:,:))
 

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -27,40 +27,43 @@
 end
 @testset "glue" begin
 
-    import TensorCast: copy_glue, glue!, static_glue, cat_glue, red_glue, lazy_glue
+    import TensorCast: copy_glue, glue!, static_glue #, cat_glue, red_glue, lazy_glue
+    using LazyStack: stack_iter
 
     B = [ SVector{2}(i .+ rand(2)) for i=1:3 ];
 
-    G0 = cat_glue(B, (:,*))
+    # G0 = cat_glue(B, (:,*))
+    G0 = stack_iter(B)
     G1 = copy_glue(B, (:,*))
     G2 = static_glue(B)
     G3 = glue!(similar(G1), B, (:,*))
-    G4 = red_glue(B, (:,*))
-    @test all(G0 .== G1 .== G2 .== G3 .== G4)
+    # G4 = red_glue(B, (:,*))
+    @test all(G0 .== G1 .== G2 .== G3)# .== G4)
 
-    G0T = cat_glue(B, (*,:))
+    # G0T = cat_glue(B, (*,:))
+    G0T = stack_iter(B)'
     G1T = copy_glue(B, (*,:))
     G3T = glue!(similar(G1T), B, (*,:))
-    G4T = red_glue(B, (*,:))
-    @test all(G0T .== G1T .== G3T .== G4T)
+    # G4T = red_glue(B, (*,:))
+    @test all(G0T .== G1T .== G3T)# .== G4T)
 
     C = [ SMatrix{2,3}(rand(2,3)) for i=1:4, j=1:5 ];
 
     H1 = copy_glue(C, (:,:,*,*))
     H2 = static_glue(C)
     H3 = glue!(similar(H1), C, (:,:,*,*))
-    H4 = red_glue(C, (:,:,*,*))
-    H5 = cat_glue(C, (:,:,*,*))
-    H6 = lazy_glue(C, (:,:,*,*))
-    @test all(H1 .== H2 .== H3 .== H4 .== H5)
+    # H4 = red_glue(C, (:,:,*,*))
+    # H5 = cat_glue(C, (:,:,*,*))
+    # H6 = lazy_glue(C, (:,:,*,*))
+    @test all(H1 .== H2 .== H3 )#.== H4 .== H5)
 
     D = [ SMatrix{2,3}(k .+ rand(2,3)) for k=1:4 ];
 
     G5 = copy_glue(D, (:,:,*))
-    G6 = cat_glue(D, (:,:,*))
-    G7 = red_glue(D, (:,:,*))
-    G8 = lazy_glue(D, (:,:,*))
-    @test all(G5 .== G6 .== G7 .== G8)
+    # G6 = cat_glue(D, (:,:,*))
+    # G7 = red_glue(D, (:,:,*))
+    # G8 = lazy_glue(D, (:,:,*))
+    # @test all(G5 .== G6 .== G7 .== G8)
 
     G8 = copy_glue(D, (:,*,:))
     G9 = glue!(similar(G8), D, (:,*,:))


### PR DESCRIPTION
Goal is to get rid of codes `(:, *, *)` etc. Not quite there for static slices, `sizeorcode = maybestaticsizes`...