### PR TITLE
Faster capture macro?

### DIFF
--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -6,6 +6,7 @@ export @cast, @reduce, @matmul, @pretty
 using MacroTools, StaticArrays, Compat
 using LinearAlgebra, Random
 
+include("capture.jl")
 include("macro.jl")
 include("pretty.jl")
 include("string.jl")

--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -1,6 +1,12 @@
 
 module TensorCast
 
+# This speeds up loading a bit... but might slow down functions which act on data:
+# https://github.com/JuliaPlots/Plots.jl/pull/2544/files
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
+    @eval Base.Experimental.@optlevel 1
+end
+
 export @cast, @reduce, @matmul, @pretty
 
 using MacroTools, StaticArrays, Compat

--- a/src/capture.jl
+++ b/src/capture.jl
@@ -1,0 +1,88 @@
+"""
+    @capture_(ex, A_[ijk__])
+
+A faster drop-in replacement for `MacroTools.@capture`, for this particular pattern only.
+"""
+macro capture_(ex, pat::Expr)
+    pat.head == :ref &&
+        length(pat.args)==2 &&
+        endswith(string(pat.args[1]), '_') &&
+        endswith(string(pat.args[2]), "__") || error("@capture_ only works on pattern A_[ijk__]")
+
+    A = Symbol(string(pat.args[1])[1:end-1])
+    ijk = Symbol(string(pat.args[2])[1:end-2])
+    @gensym res
+    quote
+        $A, $ijk = nothing, nothing
+        $res = TensorCast._trymatch($ex)
+        if $res == nothing
+            false
+        else
+            $A, $ijk = $res
+            true
+        end
+    end |> esc
+end
+
+_trymatch(s) = nothing
+function _trymatch(ex::Expr)
+    ex.head == :ref || return nothing
+    ex.args[1], ex.args[2:end]
+end
+
+#=
+
+julia> ex = :(Z[1,2,3])
+
+julia> @pretty @capture(ex, A_[ijk__])
+begin
+    A = MacroTools.nothing
+    ijk = MacroTools.nothing
+    tarsier = trymatch($(Expr(:copyast, :($(QuoteNode(:(A_[ijk__])))))), ex)
+    if tarsier == MacroTools.nothing
+        false
+    else
+        A = get(tarsier, :A, MacroTools.nothing)
+        ijk = get(tarsier, :ijk, MacroTools.nothing)
+        true
+    end
+end
+
+julia> @pretty @capture_(ex, A_[ijk__])
+begin
+    A = nothing
+    ijk = nothing
+    louse = _trymatch(ex)
+    if louse == nothing
+        false
+    else
+        (A, ijk) = louse
+        true
+    end
+end
+
+
+
+ex = :( A[i,j][k] + B[I[i],J[j],k]^2 / 2 )
+f1(x) = MacroTools.postwalk(ex) do x
+    @capture(x, A_[ijk__]) || return x
+    :($A[$(ijk...),9])
+    end
+f2(x) = MacroTools.postwalk(ex) do x
+    @capture_(x, A_[ijk__]) || return x
+    :($A[$(ijk...),9])
+    end
+f1(ex)
+f2(ex)
+
+@btime f1(x) setup=(x=ex) # 3.181 ms
+@btime f2(x) setup=(x=ex) #    31.440 μs -- 100x faster.
+
+
+$ time julia -e 'using TensorCast; TensorCast._macro(:(  Z[i,k][j] := fun(A[i,:], B[j])[k] + C[k]^2  ))'
+
+real    0m8.567s  # was 0m9.485s
+user    0m8.295s
+sys 0m0.329s
+
+=#

--- a/src/capture.jl
+++ b/src/capture.jl
@@ -4,17 +4,23 @@
 A faster drop-in replacement for `MacroTools.@capture`, for this particular pattern only.
 """
 macro capture_(ex, pat::Expr)
-    pat.head == :ref &&
+
+    pat.head in [:ref, :curly] &&
         length(pat.args)==2 &&
         endswith(string(pat.args[1]), '_') &&
-        endswith(string(pat.args[2]), "__") || error("@capture_ only works on pattern A_[ijk__]")
+        endswith(string(pat.args[2]), "__") ||
+        error("@capture_ doesn't work on pattern $pat")
 
     A = Symbol(string(pat.args[1])[1:end-1])
     ijk = Symbol(string(pat.args[2])[1:end-2])
+
+    qn = QuoteNode(pat.head)
+
     @gensym res
     quote
         $A, $ijk = nothing, nothing
-        $res = TensorCast._trymatch($ex)
+        # $res = TensorCast._trymatch($ex, Val($qn))
+        $res = _trymatch($ex, Val($qn))
         if $res == nothing
             false
         else
@@ -24,12 +30,54 @@ macro capture_(ex, pat::Expr)
     end |> esc
 end
 
-_trymatch(s) = nothing
-function _trymatch(ex::Expr)
-    ex.head == :ref || return nothing
-    ex.args[1], ex.args[2:end]
-end
+_trymatch(s, v) = nothing # s::Symbol
+_trymatch(ex::Expr, ::Val{:ref}) = # A_[ijk__]
+    if ex.head === :ref
+        ex.args[1], ex.args[2:end]
+    else
+        nothing
+    end
+_trymatch(ex::Expr, ::Val{:curly}) = # A_{ijk__}
+    if ex.head === :curly
+        ex.args[1], ex.args[2:end]
+    else
+        nothing
+    end
 
+
+    # elseif pat.head == :call && pat.args[1] === :|
+    #     length(pat.args)==3 || error("@capture_ doesn't work on pattern $pat") # Or syntax
+    #     for i in 2:3
+    #         pat.args[i].head in [:ref, :curly] &&
+    #             length(pat.args[i].args)==2 &&
+    #             endswith(string(pat.args[i].args[1]), '_') &&
+    #             endswith(string(pat.args[i].args[2]), "__") ||
+    #             error("@capture_ doesn't work on pattern $pat")
+
+    #         A = Symbol(string(pat.args[i].args[1])[1:end-1])
+    #         ijk = Symbol(string(pat.args[i].args[1])[1:end-2])
+    #     end
+    # end
+# _trymatch(ex::Expr, ::Val{:call}) = # A | B
+#     if ex.head === :call && ex.args[1] === :|
+#         ex.args[1], ex.args[2:end]
+#     else
+#         nothing
+#     end
+
+
+#     elseif pat.head === :call && pat.args[1] === :| # Or syntax
+#         left = _trymatch(pat.args[2], ex)
+#         if left !== nothing
+#             return left
+#         else
+#             return right = _trymatch(pat.args[3], ex)
+#         end
+#     end
+#     nothing
+# end
+
+# || pat.head === :curly # Patten is A_[ijk__] or A_{ijk__}
 #=
 
 julia> ex = :(Z[1,2,3])
@@ -81,8 +129,12 @@ f2(ex)
 
 $ time julia -e 'using TensorCast; TensorCast._macro(:(  Z[i,k][j] := fun(A[i,:], B[j])[k] + C[k]^2  ))'
 
-real    0m8.567s  # was 0m9.485s
+real    0m8.828s  # was 0m9.485s
 user    0m8.295s
 sys 0m0.329s
+
+$ time julia -e 'using TensorCast; @time TensorCast._macro(:(  Z[i,k][j] := fun(A[i,:], B[j])[k] + C[k]^2  ))'
+
+5.194806 seconds
 
 =#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Compat
 if VERSION >= v"1.1"
     using LoopVectorization
 end
+using TensorCast: @capture_
 
 @testset "ex-@shape" begin include("shape.jl") end
 @testset "@reduce" begin include("reduce.jl")  end


### PR DESCRIPTION
This `@capture` replacement is 100x quicker, but fixing one pattern doesn't improve the package startup speed much.