### PR TITLE
Disable 3-factor `@matmul`

### DIFF
--- a/test/two.jl
+++ b/test/two.jl
@@ -206,6 +206,8 @@ end
     @test A[end] == π / ℯ
 
 end
+#=
+# disabled for v0.3, since I haven't got around to fixing it.
 @testset "A * B * C" begin
 
     A = rand(2,2)
@@ -217,6 +219,7 @@ end
     @test vec(Z) == vec(A * B * C)
 
 end
+=#
 @testset "string macros" begin
 
     A = rand(2,10); B = rand(10,10);


### PR DESCRIPTION
Things like this have given a warning for ages:
```julia
@matmul Z[i,l] := sum(j,k) A[i,j] * B[j,k] * C[k,l]
```
because there are bugs in how cases that need reshaping get handled. Perhaps this should simply be removed.