### PR TITLE
Do not count empty indices as constant

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -249,7 +249,9 @@ function standardise(ex, store::NamedTuple, call::CallInfo; LHS=false)
     end
 
     # Constant indices A[i,3], A[i,_], A[i,$c], and also A[i,3:5]
-    if all(isCorR, ijk)
+    if isempty(ijk)
+        # empty indices do not count as constant - this fixes some issues with 0d CuArrays
+    elseif all(isCorR, ijk)
         needview!(ijk)                                         # replace _ with 1, if any
         Asym = maybepush(:( $A[$(ijk...)] ), store, :allconst) # protect from later processing
         return Asym                                            # and nothing more to do here


### PR DESCRIPTION
Currently, a (0D) array that is called with empty indices (`A[]`) within `@cast` is treated as a constant scalar expression and not included in the broadcast. This fails for 0D CuArrays if `CUDA.allowscalar(false)` has been set. Minimum example:
```julia
using TensorCast
using CUDA
CUDA.allowscalar(false)

A = CUDA.ones(Float64,())
B = CUDA.ones(Float64,())
@cast C[] := A[] * B[]
```
where the macro expands to (shown with `@pretty`)
```julia
begin
    local polarbear = A[]
    local leopard = B[]
    local ape = polarbear * leopard
    C = @__dot__(ape)
end
```

Running it with CUDA 0D arrays as above, this gives
```julia
ERROR: LoadError: scalar getindex is disallowed
```

With the change in this pull request, the macro instead expands to simply
```julia
begin
    C = @__dot__(A * B)
end
```
which runs without problems. I've checked that the test suite still works, and have also used this for more complex expressions where 0D and higher-dimensional arrays are mixed, it worked for all of them. Since the error only shows up with CUDA arrays and there is currently no dependence on CUDA in the package or test suite, I didn't add any tests.