### PR TITLE
Allow `@cast` with a non-reducing function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorCast"
 uuid = "02d47bb6-7ce6-556a-be16-bb1710789e2b"
 authors = ["Michael Abbott"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/reduce.md
+++ b/docs/src/reduce.md
@@ -171,3 +171,18 @@ julia> @btime lazyred($A, $B);
 ```
 
 More details on the next page. 
+
+## No reduction
+
+The syntax of `@reduce` can also be used with `@cast`, to apply functions which 
+take a `dims` keyword, but do not produce trivial dimensions. 
+
+```jldoctest mylabel
+julia> normalise(p; dims) = p ./ sum(p; dims=dims);
+
+julia> @cast N[x,y] := normalise(x) M[x,y]
+3×4 Array{Float64,2}:
+ 0.166667  0.266667  0.291667  0.30303
+ 0.333333  0.333333  0.333333  0.333333
+ 0.5       0.4       0.375     0.363636
+```

--- a/test/two.jl
+++ b/test/two.jl
@@ -182,13 +182,13 @@ end
     normalise(p; dims) = p ./ sum(p; dims=dims)
 
     @cast M2[i,j] := normalise(j) abs(M[i,j])
-    @test all(≈(1), sum(M2, dims=2))
+    @test all(x->(x≈1), sum(M2, dims=2))
 
     # not many functions behave like this, but at least the error will make sense!
     normalise!(dst, src; dims) = dst .= src ./ sum(src; dims=dims)
     M1 = similar(M)
     @cast M1[i,j] = normalise(i) abs(M[i,j])
-    @test all(≈(1), sum(M1, dims=1))
+    @test all(x->(x≈1), sum(M1, dims=1))
 
 end
 @testset "tupple broadcasting" begin

--- a/test/two.jl
+++ b/test/two.jl
@@ -176,6 +176,21 @@ end
     @test_broken V isa Array{Float64,0}
 
 end
+@testset ":dimcast" begin
+
+    M = randn(3,4)
+    normalise(p; dims) = p ./ sum(p; dims=dims)
+
+    @cast M2[i,j] := normalise(j) abs(M[i,j])
+    @test all(≈(1), sum(M2, dims=2))
+
+    # not many functions behave like this, but at least the error will make sense!
+    normalise!(dst, src; dims) = dst .= src ./ sum(src; dims=dims)
+    M1 = similar(M)
+    @cast M1[i,j] = normalise(i) abs(M[i,j])
+    @test all(≈(1), sum(M1, dims=1))
+
+end
 @testset "tupple broadcasting" begin
 
     V = 1:4


### PR DESCRIPTION
This allows things like
```julia
@cast P[i,j,k] := softmax(j) Q[i,k] / R[j,k]
```
with a function which takes a `dims` keyword, but does not reduce along that dimension.