### PR TITLE
Re-work how options work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"
 JuliennedArrays = "5cadff95-7770-533d-a838-a1bf817ee6e0"
 LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -37,4 +38,4 @@ Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Compat", "Einsum", "JuliennedArrays", "LazyArrays", "LoopVectorization", "OffsetArrays", "Statistics", "Strided"]
+test = ["Test", "Compat", "Einsum", "JuliennedArrays", "LazyArrays", "LoopVectorization", "Logging", "OffsetArrays", "Statistics", "Strided"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ All of these are converted into array commands like `reshape` and `permutedims`
 and `eachslice`, plus a [broadcasting expression](https://julialang.org/blog/2017/01/moredots) if needed, 
 and `sum` /  `sum!`, or `*` / `mul!`. This package just provides a convenient notation.
 
+It can be used with some other packages which modify broadcasting, including:
+
+```julia
+using Strided, LoopVectorization
+@cast @strided E[φ,γ] = F[φ]^2 * exp(G[γ])           # multi-threaded
+@reduce @avx S[i] := sum(n) -P[i,n] * log(P[i,n])    # SIMD-enhanced
+```
+
 ## Installation
 
 ```julia

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -179,12 +179,12 @@ julia> Base.kron(A::Array{T,3}, X::Array{T′,3}) where {T,T′} =    # extend k
 If an array on the right has a combined index, then it may be ambiguous how to divide up its range. You can resolve this by providing explicit ranges, after the main expression: 
 
 ```jldoctest mylabel
-julia> @cast A[i,j] := collect(1:12)[i⊗j]  i:2
+julia> @cast A[i,j] := collect(1:12)[i⊗j]  i in 1:2
 2×6 Array{Int64,2}:
  1  3  5  7   9  11
  2  4  6  8  10  12
 
-julia> @cast A[i,j] := collect(1:12)[i⊗j]  i:4, j:3
+julia> @cast A[i,j] := collect(1:12)[i⊗j]  i ∈ 1:4, j ∈ 1:3
 4×3 Array{Int64,2}:
  1  5   9
  2  6  10
@@ -202,7 +202,7 @@ julia> @cast A[i,j] = 10 * collect(1:12)[i⊗j];
 Aside, note that providing explicit ranges will also turn on checks of the input, for example:
 
 ```julia
-julia> @pretty @cast W[i] := V[i]^2  i:3 
+julia> @pretty @cast W[i] := V[i]^2  i ∈ 1:3 
 begin
     @assert_ 3 == size(V, 1) "range of index i must agree"
     @assert_ ndims(V) == 1 "expected a 1-tensor V[i]"
@@ -219,7 +219,7 @@ agrees with that of two indices `x,i`.
 ```jldoctest mylabel
 julia> list = [ i .* ones(2,2) for i=1:8 ];
 
-julia> @cast mat[x⊗i, y⊗j] := Int(list[i⊗j][x,y])  i:2
+julia> @cast mat[x⊗i, y⊗j] := Int(list[i⊗j][x,y])  i in 1:2
 4×8 Array{Int64,2}:
  1  1  3  3  5  5  7  7
  1  1  3  3  5  5  7  7
@@ -275,7 +275,7 @@ Acting on elements, `C[i,j]'` means `adjoint.(C)`, elementwise complex conjugate
 If the elements are matrices, as in `C[:,:,k]'`, then  `adjoint` is conjugate transpose.
 
 ```jldoctest mylabel
-julia> @cast C[i,i'] := (1:4)[i⊗i′] + im  (i:2, i′:2)
+julia> @cast C[i,i'] := (1:4)[i⊗i′] + im  (i ∈ 1:2, i′ ∈ 1:2)
 2×2 Array{Complex{Int64},2}:
  1+1im  3+1im
  2+1im  4+1im

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -98,7 +98,7 @@ as it does not have to infer what shape the function produces:
 ```julia-repl
 julia> using BenchmarkTools
 
-julia> f(M) = @cast [i,j] := cumsum(M[:,j])[i];
+julia> f(M) = @cast _[i,j] := cumsum(M[:,j])[i];
 
 julia> M10 = rand(10,1000);
 
@@ -173,7 +173,7 @@ julia> all(K[i + 3(j-1)] == V[i] * W[j] for i=1:3, j=1:4)
 true
 
 julia> Base.kron(A::Array{T,3}, X::Array{T′,3}) where {T,T′} =    # extend kron to 3-tensors
-           @cast [x⊗a, y⊗b, z⊗c] := A[a,b,c] * X[x,y,z]
+           @cast _[x⊗a, y⊗b, z⊗c] := A[a,b,c] * X[x,y,z]
 ```
 
 If an array on the right has a combined index, then it may be ambiguous how to divide up its range. You can resolve this by providing explicit ranges, after the main expression: 
@@ -226,7 +226,7 @@ julia> @cast mat[x⊗i, y⊗j] := Int(list[i⊗j][x,y])  i in 1:2
  2  2  4  4  6  6  8  8
  2  2  4  4  6  6  8  8
 
-julia> vec(mat) == @cast [xi⊗yj] := mat[xi, yj]
+julia> vec(mat) == @cast _[xi⊗yj] := mat[xi, yj]
 true
 
 julia> mat == Int.(hvcat((4,4), transpose(reshape(list,2,4))...))
@@ -280,12 +280,12 @@ julia> @cast C[i,i'] := (1:4)[i⊗i′] + im  (i ∈ 1:2, i′ ∈ 1:2)
  1+1im  3+1im
  2+1im  4+1im
 
-julia> @cast [i,j] := C[i,j]'
+julia> @cast _[i,j] := C[i,j]'
 2×2 Array{Complex{Int64},2}:
  1-1im  3-1im
  2-1im  4-1im
 
-julia> C' == @cast [j,i] := C[i,j]'
+julia> C' == @cast _[j,i] := C[i,j]'
 true
 ```
 
@@ -314,7 +314,7 @@ You can also index one array using another, this example is just `view(M, :, ind
 ```jldoctest mylabel
 julia> ind = [1,1,2,2,4];
 
-julia> @cast [i,j] := M[i,ind[j]]
+julia> @cast _[i,j] := M[i,ind[j]]
 3×5 view(::Array{Int64,2}, :, [1, 1, 2, 2, 4]) with eltype Int64:
  1  1  4  4  10
  2  2  5  5  11
@@ -332,7 +332,7 @@ julia> @cast D[i] |= C[i,i]
  1 + 1im
  4 + 1im
 
-julia> D2 = @cast [i,i] := V[i]
+julia> D2 = @cast _[i,i] := V[i]
 3×3 Diagonal{Int64,Array{Int64,1}}:
  10   ⋅   ⋅
   ⋅  20   ⋅

--- a/docs/src/docstrings.md
+++ b/docs/src/docstrings.md
@@ -37,16 +37,6 @@ These provide an alternative... but don't cover quite everything:
 These are not exported, but are called by the macros above, 
 and visible in what `@pretty` prints out. 
 
-## Reshaping & views
-
-```@docs
-TensorCast.orient
-```
-
-```@docs
-TensorCast.PermuteDims
-```
-
 ```@docs
 TensorCast.rview
 ```
@@ -55,13 +45,6 @@ TensorCast.rview
 TensorCast.diagview
 ```
 
-## Slicing & glueing
-
 ```@docs
 TensorCast.sliceview
 ```
-
-```@docs
-TensorCast.glue
-```
-

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,21 +5,22 @@ which are turned into Julia's usual broadcasting, permuting, slicing, and reduci
 It does little you couldn't do yourself, but provides a notation in which it is often 
 easier to confirm that you are doing what you intend.
 
+Source, issues, etc: [github.com/mcabbott/TensorCast.jl](https://github.com/mcabbott/TensorCast.jl)
+
+## Changes
+
 Version 0.2 was a re-write, see the [release notes](https://github.com/mcabbott/TensorCast.jl/releases/tag/v0.2.0) to know what changed from version 0.1.5.
 
 Version 0.4 has significant changes:
+- Options are now written `@cast @avx A[i,j] = B[i⊗j] (i ∈ 1:3)` instead of `@cast A[i,j] = B[i⊗j] i:3, axv` (using [LoopVectorization.jl](https://github.com/JuliaSIMD/LoopVectorization.jl) for the broadcast, and supplying the range of `i`).
+- To return an array without naming it, write an underscore `@cast _[i] := ...` rather than omitting it entirely.
 - It uses [TransmuteDims.jl](https://github.com/mcabbott/TransmuteDims.jl) to handle all permutations & many reshapes. This is lazier by default, which isn't always faster: The earlier code avoids reshaping a `PermutedDimsArray` by copying it. 
 - It uses [LazyStack.jl](https://github.com/mcabbott/LazyStack.jl) to combine handles slices, simplifying earlier code.
 - It inserts some dimension checks by default, previously the option `assert` did this.
 
-Source, issues, etc: [github.com/mcabbott/TensorCast.jl](https://github.com/mcabbott/TensorCast.jl)
-
-## Documentation
-
-The pages are:
+## Pages
 
 1. Use of `@cast` for broadcasting, and slicing
 2. `@reduce` and `@matmul`, for summing over some directions
 3. Options: StaticArrays, LazyArrays, Strided
 4. Docstrings, for all details.
-

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -8,10 +8,10 @@ But unlike those packages, sometimes the result of `@cast` is a view of the orig
 by writing `|=` instead (or passing the option `collect`). 
 
 Various other options can be given after the main expression. `assert` turns on explicit size checks, 
-and ranges like `i:3` specify the size in that direction (sometimes this is necessary to specify the shape).
+and ranges like `i ∈ 1:3` specify the size in that direction (sometimes this is necessary to specify the shape).
 Adding these to the example above: 
 ```julia
-@pretty @cast A[(i,j)] = B[i,j]  i:3, assert
+@pretty @cast A[(i,j)] = B[i,j]  i ∈ 1:3, assert
 # begin
 #     @assert_ ndims(B) == 2 "expected a 2-tensor B[i, j]"
 #     @assert_ 3 == size(B, 1) "range of index i must agree"
@@ -50,7 +50,7 @@ in which a Vector of SVectors is just a different interpretation of the same mem
 By another slight abuse of notation, such slices are written here as curly brackets:
 
 ```julia
-@cast S[k]{i} := M[i,k]  i:3        # S = reinterpret(SVector{3,Int}, vec(M)) 
+@cast S[k]{i} := M[i,k]  i in 1:3   # S = reinterpret(SVector{3,Int}, vec(M)) 
 @cast S[k] := M{:3, k}              # equivalent
 
 @cast R[k,i] := S[k]{i}             # such slices can be reinterpreted back again

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -88,27 +88,26 @@ V = rand(500); V3 = reshape(V,1,1,:);
 However, right now this gives `3.7 s (250 M allocations, 9 GB)`, something is broken!
 
 The package [Strided.jl](https://github.com/Jutho/Strided.jl) can apply multi-threading to 
-broadcasting, and some other magic. You can enable it with the option `strided`, like this: 
+broadcasting, and some other magic. You can enable it like this: 
 
 ```julia
 using Strided # and export JULIA_NUM_THREADS = 4 before starting
 A = randn(4000,4000); B = similar(A);
 
 @time @cast B[i,j] = (A[i,j] + A[j,i])/2;             # 0.12 seconds
-@time @cast B[i,j] = (A[i,j] + A[j,i])/2 strided;     # 0.025 seconds
+@time @cast @strided B[i,j] = (A[i,j] + A[j,i])/2;    # 0.025 seconds
 ```
 
 The package [LoopVectorization.jl](https://github.com/chriselrod/LoopVectorization.jl) provides 
 a macro `@avx` which modifies broadcasting to use vectorised instructions. 
-This is new and does not work for all broadcasting operations! 
-But it can be used via the option `avx`:
+This can be used as follows:
 
 ```julia
 using LoopVectorization, BenchmarkTools
 C = randn(40,40); 
 
-D = @btime @cast [i,j] := exp($C[i,j]);        # 13 μs
-D′ = @btime @cast [i,j] := exp($C[i,j]) avx;   #  3 μs
+D = @btime @cast [i,j] := exp($C[i,j]);         # 13 μs
+D′ = @btime @cast @avx [i,j] := exp($C[i,j]);   #  3 μs
 D ≈ D′
 ```
 

--- a/docs/src/reduce.md
+++ b/docs/src/reduce.md
@@ -62,8 +62,8 @@ and keep the maximum of each set -- equivalent to the maximum of each column bel
 ```jldoctest mylabel
 julia> R = collect(0:5:149);
 
-julia> @reduce Rmax[_,c] := maximum(r) R[(r,c)]  r:3
-1×10 LinearAlgebra.Transpose{Int64,Array{Int64,1}}:
+julia> @reduce Rmax[_,c] := maximum(r) R[(r,c)]  r in 1:3
+1×10 Array{Int64,2}:
  10  25  40  55  70  85  100  115  130  145
 
 julia> reshape(R, 3,:)
@@ -73,7 +73,7 @@ julia> reshape(R, 3,:)
  10  25  40  55  70  85  100  115  130  145
 ```
 
-Here `r:3` indicates the range of `r`, implying `c ∈ 1:10`. 
+Here `r in 1:3` indicates the range of `r`, implying `c ∈ 1:10`.
 You may also write `maximum(r:3) R[(r,c)]`.
 
 In the same way, this down-samples an image by a factor of 2, 
@@ -110,7 +110,7 @@ then you can place a complete `@reduce` expression inside `@cast` or `@reduce`.
 There is no need to name the intermediate array, here `termite[x]`, but you must show its indices:
 
 ```julia-repl
-julia> @pretty @reduce sum(x,θ) L[x,θ] * p[θ] * log(L[x,θ] / @reduce [x] := sum(θ′) L[x,θ′] * p[θ′])
+julia> @pretty @reduce sum(x,θ) L[x,θ] * p[θ] * log(L[x,θ] / @reduce _[x] := sum(θ′) L[x,θ′] * p[θ′])
 begin
     local fish = transmute(p, (nothing, 1))
     termite = transmute(sum(@__dot__(L * fish), dims = 2), (1,))

--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -35,7 +35,7 @@ module Fast # shield non-macro code from @optlevel 1
     export sliceview, slicecopy, copy_glue, glue!, iscodesorted, countcolons
 
     include("view.jl")
-    export diagview, mul!, rview, star, Reverse, Shuffle
+    export diagview, mul!, rview, star, onetolength, Reverse, Shuffle
 
     include("static.jl")
     export static_slice, static_glue

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -963,7 +963,17 @@ function optionparse(opt, store::NamedTuple, call::CallInfo)
         return
     end
 
-    if @capture(opt, i_:s_)
+    if @capture(opt, i_ in ax_) || @capture(opt, i_ ∈ ax_)
+        if @capture(ax, 1:s_)
+            saveonesize(tensorprimetidy(i), s, store)
+        else
+            ax isa Number && @warn "did you mean `$i in $ax`, not `$i in 1:$ax`?"
+            # ax1 = maybepush(ax, store, :axis) # this pushes to main, too late!
+            saveonesize(tensorprimetidy(i), :(TensorCast.onetolength($ax)), store)
+        end
+        push!(call.flags, :assert)
+    elseif @capture(opt, i_:s_)
+        @warn "please replace index ranges like `i:3` with `i in 1:3` or `i ∈ 1:3`"
         saveonesize(tensorprimetidy(i), s, store)
         push!(call.flags, :assert)
     elseif opt in (:assert, :lazy, :nolazy, :strided, :avx)

--- a/src/view.jl
+++ b/src/view.jl
@@ -35,6 +35,14 @@ star(::Colon,y) = Colon()
 star(x,::Colon) = Colon()
 star(x,y,zs...) = star(star(x,y), zs...)
 
+"""
+    onetolength(1:10) == 10
+
+Used to digest options `i in 1:10`, size calculation for reshaping only allows ranges starting at 1 for now.
+"""
+onetolength(ax::Base.OneTo) = length(ax)
+onetolength(ax::AbstractUnitRange) = first(ax) == 1 ? length(ax) : error("ranges have to start at 1, for now")
+onetolength(ax) = error("ranges must be AbstractUnitRange")
 
 struct Reverse{D} end
 

--- a/test/four.jl
+++ b/test/four.jl
@@ -1,5 +1,9 @@
 
 @testset "new macro notation" begin
-    A = [i^2 for i in 1:10]
+    A = [i^2 for i in 1:12]
     @test A .+ 1 == @cast @strided B[i] := A[i] + 1
+
+    @test reshape(A,3,4) == @cast C[i,j] := A[(i,j)]  i in 1:3
+
+    @test_logs min_level=Logging.Warn @reduce D[i] := sum(j:4) A[i⊗j]
 end

--- a/test/four.jl
+++ b/test/four.jl
@@ -1,0 +1,5 @@
+
+@testset "new macro notation" begin
+    A = [i^2 for i in 1:10]
+    @test A .+ 1 == @cast @strided B[i] := A[i] + 1
+end

--- a/test/four.jl
+++ b/test/four.jl
@@ -1,9 +1,23 @@
 
 @testset "new macro notation" begin
     A = [i^2 for i in 1:12]
+
+    # @strided broadcasting
     @test A .+ 1 == @cast @strided B[i] := A[i] + 1
 
+    # index ranges
     @test reshape(A,3,4) == @cast C[i,j] := A[(i,j)]  i in 1:3
-
     @test_logs min_level=Logging.Warn @reduce D[i] := sum(j:4) A[i⊗j]
+
+    # underscores 
+    @test A' == @cast _[_,i] := A[i]
+
+    # ... use in recursion, reads from the _ just written to:
+    A = rand(4);
+    B = randn(4,4);
+    R1 = @reduce sum(i) A[i] * log( @reduce _[i] := sum(j) A[j] * exp(B[i,j]) ) # new
+    R2 = @reduce sum(i) A[i] * log( @reduce [i] := sum(j) A[j] * exp(B[i,j]) ) # old, with warning
+    @reduce inner[i] := sum(j) A[j] * exp(B[i,j])
+    S = @reduce sum(i) A[i] * log(inner[i])
+    @test S == R1 == R2
 end

--- a/test/mul.jl
+++ b/test/mul.jl
@@ -171,9 +171,9 @@ end
     @einsum V[i,l] := A[i,j] * B[j,k] * C[k,l]
     @reduce V2[i,l] := sum(j,k) A[i,j] * B[j,k] * C[k,l]
 
-    @reduce W[i,l] := sum(j) A[i,j] * @matmul [j,l] := sum(k) B[j,k] * C[k,l]
+    @reduce W[i,l] := sum(j) A[i,j] * @matmul _[j,l] := sum(k) B[j,k] * C[k,l]
 
-    # @matmul W2[i,l] := sum(j) A[i,j] * @matmul [j,l] := B[j,k] * C[k,l]
+    # @matmul W2[i,l] := sum(j) A[i,j] * @matmul _[j,l] := B[j,k] * C[k,l]
     # maybe I decided not to allow this for now.
 
     @test V ≈ V2 ≈ W #≈ W2

--- a/test/old.jl
+++ b/test/old.jl
@@ -64,11 +64,11 @@ end
 
 
     B = [rand(3) for i=1:4];
-    A = @cast [(i,j)] := B[j][i]  # vcat a vector of vectors
+    A = @cast _[(i,j)] := B[j][i]  # vcat a vector of vectors
     @test size(A) == (12,)
 
     B = [rand(3,4,5,6) for i=1:7];
-    A = @cast [(i,j),l][k,m] := B[i][j,k,l,m]; # glue then slice then reshape
+    A = @cast _[(i,j),l][k,m] := B[i][j,k,l,m]; # glue then slice then reshape
     @test size(A) == (21,5)
 
 

--- a/test/old.jl
+++ b/test/old.jl
@@ -9,23 +9,23 @@
 
 
     B = rand(2*5, 3)
-    @cast A[i,j,k] := B[(i,k),j]  i:2
+    @cast A[i,j,k] := B[(i,k),j]  i in 1:2
     @test size(A) == (2,3,5)
     @cast A[i,j,k] = B[(i,k),j];
 
 
     imgs = [ rand(8,8) for i=1:16 ];
 
-    @cast G[(i,I), (j,J)] := imgs[(I,J)][i,j] J:4
+    @cast G[(i,I), (j,J)] := imgs[(I,J)][i,j] J in 1:4
     @cast G[ i⊗I,   j⊗J ] = imgs[ I⊗J ][i,j] # in-place
 
 
     G = rand(16,32);
 
-    @reduce H[a, b] := maximum(α,β)  G[α⊗a, β⊗b]  α:2,β:2
+    @reduce H[a, b] := maximum(α,β)  G[α⊗a, β⊗b]  α in 1:2, β in 1:2
     @test size(G) == 2 .* size(H)
 
-    @reduce H4[a, b] := maximum(α:4,β:4)  G[α⊗a, β⊗b]
+    @reduce H4[a, b] := maximum(α:4,β:4)  G[α⊗a, β⊗b]  # doesn't warn
     @test size(G) == 4 .* size(H4)
 
     W = randn(2,3,5,7);
@@ -73,16 +73,16 @@ end
 
 
     B = rand(2*5, 3);
-    @cast A[i,j,k] := B[(i,k),j]  i:2  # could give (i:2, j:3, k:5)
+    @cast A[i,j,k] := B[(i,k),j]  i in 1:2  # could give (i:2, j:3, k:5)
     @test size(A) == (2,3,5)
 
-    @cast A[i,j,k] := B[(i,k),j]  (i:2, j:3, k:5)
+    @cast A[i,j,k] := B[(i,k),j]  (i in 1:2, j in 1:3, k in 1:5)
     @test size(A) == (2,3,5)
 
 
     @pretty @cast A[(i,j)] = B[i,j]
 
-    @pretty @cast A[k][i,j] := B[i,(j,k)]  k:length(C)
+    @pretty @cast A[k][i,j] := B[i,(j,k)]  k in 1:length(C)
 
 
     M = rand(3,4)
@@ -98,7 +98,7 @@ end
     using StaticArrays
     M = rand(1:99, 2,3)
 
-    @cast S[k]{i} := M[i,k]  i:2  # S = reinterpret(SVector{2,Int}, vec(M)) needs the 2
+    @cast S[k]{i} := M[i,k]  i in 1:2  # S = reinterpret(SVector{2,Int}, vec(M)) needs the 2
     @cast N[k,i] := S[k]{i}       # such slices can be reinterpreted back again
 
     M[1,2]=42; N[2,1]==42          # all views of the original matrix

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -15,7 +15,7 @@
 	V = vec(mean(bcde, dims=(2,4)))
 	@test V == W
 
-	@reduce Z[e,b,β] := Statistics.std(c,α:2) bcde[b,c,α⊗β,e] assert
+	@reduce Z[e,b,β] := Statistics.std(c,α) bcde[b,c,α⊗β,e] assert, α in 1:2
 	@test size(Z) == (5,2,2)
 
 	@reduce A[_,e,_,b] := sum(c) bcde[b,c,3,e]
@@ -28,10 +28,12 @@
 
 	@reduce D[b][c] := sum(d,e) bcde[b,c,d,e] + 1
 	@reduce E[b][c] := sum(e,d) bcde[b,c,d,e] + 1
-	@reduce F[c][b] := sum(d:4,e:5) bcde[b,c,d,e] + 1
+	@reduce F[c][b] := sum(d:4,e:5) bcde[b,c,d,e] + 1 # doesn't warn
+    @reduce F′[c][b] := sum(d,e) bcde[b,c,d,e] + 1  d in 1:4, e in 1:5
 
 	@test D[1][2] ≈ sum(bcde, dims=(3,4))[1,2, 1,1] + 4*5
 	@test D[1][2] ≈ E[1][2] ≈ F[2][1]
+    @test F′ ≈ F
 
 end
 @testset "scalar" begin
@@ -48,7 +50,7 @@ end
 
     # inference for a⊗b⊗c had an (Any[]...) dots problem at first
     B = randn(8,24);
-    @reduce A[b,c, y,z] := sum(a:2, x:2) B[a⊗b⊗c, x⊗y⊗z]  b:2, y:3, assert
+    @reduce A[b,c, y,z] := sum(a:2, x:2) B[a⊗b⊗c, x⊗y⊗z]  b in 1:2, y in 1:3, assert
     @test size(A) == (2,2, 3,4)
 
     C = similar(A)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -67,7 +67,7 @@ end
     # from readme
     A = rand(4);
     B = randn(4,4);
-    R = @reduce sum(i) A[i] * log( @reduce [i] := sum(j) A[j] * exp(B[i,j]) )
+    R = @reduce sum(i) A[i] * log( @reduce _[i] := sum(j) A[j] * exp(B[i,j]) )
     @reduce inner[i] := sum(j) A[j] * exp(B[i,j])
     S = @reduce sum(i) A[i] * log(inner[i])
     @test S == R
@@ -83,7 +83,7 @@ end
 
     # this needs size of the result of inner macro, failed at first:
     A = rand(2,3); B = rand(3,4); C = rand(4,5);
-    @reduce W[i,_,l] := sum(j) A[i,j] * (@matmul [j,l] := sum(k) B[j,k] * C[k,l])  assert
+    @reduce W[i,_,l] := sum(j) A[i,j] * (@matmul _[j,l] := sum(k) B[j,k] * C[k,l])  assert
     @test W ≈ reshape(A * B * C, 2,1,5)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,3 +20,4 @@ end
 @testset "slice/view"  begin include("cat.jl") end
 @testset "old readmes" begin include("old.jl") end
 @testset "new in 0.2"  begin include("two.jl") end
+@testset "new in 0.4" begin include("four.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,11 @@
 
 using TensorCast
+
 using Test
 using LinearAlgebra
 using StaticArrays
+using Logging
+
 using OffsetArrays
 using Einsum
 using Strided

--- a/test/shape.jl
+++ b/test/shape.jl
@@ -11,10 +11,10 @@ usingstatic =   isdefined(TensorCast, :StaticArray)
     @test β == 99
     @test all(cb .== transpose(bc))
 
-    @cast cb[c,b] = bc[b,c] c:3 # in-place
+    @cast cb[c,b] = bc[b,c] c in 1:3 # in-place
 
     β = 2
-    @cast f[(c,b)] := bc[b,c] b:β, c:3 # @assert uses β
+    @cast f[(c,b)] := bc[b,c] b:β, c in 1:3 # @assert uses β
     @test size(f) == (6,)
     @cast cb2[c,b] := f[(c,b)] b:β # can't not use this
     @test size(cb2) == (3,2)
@@ -97,7 +97,7 @@ end
 
     M = rand(Int, 2,3)
     S1 = reinterpret(SVector{2,Int}, vec(M)) # as in readme
-    @cast S2[k]{i} := M[i,k]  i:2
+    @cast S2[k]{i} := M[i,k]  i in 1:2
     M[end]=42
     @test S1[3][2]==42 # is a view
     @test S2[3][2]==42
@@ -106,25 +106,25 @@ end
     @test size(first(S1)) == (2,)
     @test size(first(S2)) == (2,)
 
-    @cast S3[k]{i} := M[k,i]  i:3 # this has a permutedims
+    @cast S3[k]{i} := M[k,i]  i in 1:3 # this has a permutedims
     @test first(S3) isa StaticArray
     @test size(first(S3)) == (3,)
 
     bcd = rand(2,3,4);
     bcde = rand(2,3,4,5);
 
-    @cast DBec[d,b]{e,c} := bcde[b,c,d,e] e:5, c:3
+    @cast DBec[d,b]{e,c} := bcde[b,c,d,e] e:5, c in 1:3
     @test size(DBec) == (4,2)
     @test size(first(DBec)) == (5,3)
     @test first(DBec) isa StaticArray
 
-    @cast DEbc[d,e]{b,c} := bcde[b,c,d,e] b:2, c:3
+    @cast DEbc[d,e]{b,c} := bcde[b,c,d,e] b:2, c in 1:3
     @test size(DEbc) == (4,5)
     @test size(first(DEbc)) == (2,3)
     @test first(DEbc) isa StaticArray
 
     A = rand(3,3,4)
-    @cast B[k]{i,j} := A[i,j,k]  i:3, j:3
+    @cast B[k]{i,j} := A[i,j,k]  i in 1:3, j in 1:3
     @cast C[(j,k),i] := B[k][i,j]
     @test C[1,2] == B[1][2,1] ==  A[2,1,1]
 
@@ -159,14 +159,14 @@ end
 
     B = [ SVector{3}(rand(3)) for i=1:2]
 
-    @cast A[j,i] := B[i]{j} i:2, j:3 # view is impossible without Static slices
+    @cast A[j,i] := B[i]{j} i in 1:2, j in 1:3 # view is impossible without Static slices
     @test size(A) == (3,2)
     @test !isa(A, Array)
 
     A[1,2] = 33
     @test B[2][1] == 33 # mutating B illegally?
 
-    @cast A[i,j] := B[i]{j} j:3
+    @cast A[i,j] := B[i]{j} j in 1:3
     @test size(A) == (2,3)
     @test !isa(A, StaticArray)
 
@@ -174,11 +174,11 @@ end
 
     C = [ SMatrix{2,3}(rand(2,3)) for i=1:4, j=1:5 ];
 
-    @cast A[l,k,j,i] := C[i,j]{k,l} k:2, l:3
+    @cast A[l,k,j,i] := C[i,j]{k,l} k in 1:2, l in 1:3
     @test A[1,2,3,4] == C[4,3][2,1]
     @test size(A) == (3,2,5,4)
 @test_skip begin
-    @cast A[l,k,j,i] = C[i,j]{k,l} k:2, l:3 # now in-place -- fails!
+    @cast A[l,k,j,i] = C[i,j]{k,l} k in 1:2, l in 1:3 # now in-place -- fails!
     @test A[1,2,3,4] == C[4,3][2,1]
 
     @cast A[l,k,j,i] = C[i,j][k,l] # now without static glue
@@ -203,14 +203,14 @@ end
     bcde2 = similar(bcde)
 
     @cast v[(b,zc,d)] := bcd[b,zc,d]
-    @cast w[d,(zc,b)] := v[(b,zc,d)] b:2, zc:3 # add z sometimes to mess with alphabetisation
-    @cast dbc[d,b,c] := w[d,(c,b)] c:3
+    @cast w[d,(zc,b)] := v[(b,zc,d)] b in 1:2, zc in 1:3 # add z sometimes to mess with alphabetisation
+    @cast dbc[d,b,c] := w[d,(c,b)] c in 1:3
 
     @test size(w) == (4,6)
     @test size(dbc) == (4,2,3)
     @test dbc[1,2,3] == bcd[2,3,1]
 
-    @cast g[(b,c),x,y,e] := bcde[b,c,(x,y),e] x:2;
+    @cast g[(b,c),x,y,e] := bcde[b,c,(x,y),e] x in 1:2;
     @test size(g) == (6,2,2,5)
 
     @cast g[(y,e),(b,c),x] := bcde[b,c,(x,y),e] x:1;
@@ -224,7 +224,7 @@ end
     Bc = [ rand(3) for b=1:2 ] # Bc = [(1:3) .+ 10i for i=1:2]
     @cast f[(b,c)] |= Bc[b][c] # NOT a view of Bc
     @test size(f) == (6,)
-    @cast bc[b,c] |= f[(b,c)] b:2 # for in-place to work below, this bc is NOT a view of f
+    @cast bc[b,c] |= f[(b,c)] b in 1:2 # for in-place to work below, this bc is NOT a view of f
     @test size(bc) == (2,3)
     @test bc[1,2] == Bc[1][2]
 
@@ -291,19 +291,19 @@ end
 
     @cast A[i,j,k] = B[i,(k,j)] # errored on push_checks for a while
 
-    @cast A[i,j,k] = B[i,(j,k)] i:1
+    @cast A[i,j,k] = B[i,(j,k)] i in 1:1
 
-    @cast V[(i,j,k)] := B[i,(k,j)]  k:3, assert # was an error for recursive colon reasons
+    @cast V[(i,j,k)] := B[i,(k,j)]  k in 1:3, assert # was an error for recursive colon reasons
 
 
     A = @cast [jk,i] := B[i,jk] # without left-hand name
     @test size(A) == (6,1)
 
-    A = @cast [k,j,i] := B[i,(j,k)] k:3 # without left-hand name
+    A = @cast [k,j,i] := B[i,(j,k)] k in 1:3 # without left-hand name
     @test size(A) == (3,2,1)
 
-    C = @cast [k][i,j] := B[i,(j,k)]  k:3 # without left-hand name
-    C = @cast [k][i,j] := B[i,(j,k)]  j:2, k:3
+    C = @cast [k][i,j] := B[i,(j,k)]  k in 1:3 # without left-hand name
+    C = @cast [k][i,j] := B[i,(j,k)]  j in 1:2, k in 1:3
 
     @test size(C) == (3,)
     @test size(first(C)) == (1,2)
@@ -315,13 +315,13 @@ end
 
     D = randn(1*2*3, 4)
     # these two both result in a product of sizes like ((sz[2] * :) * s[4]) with : on 2nd level.
-    @cast C[i,(j,k,l)] := D[(i,j,k),l] i:1, j:2 # gets sz... from colonise! too
-    @cast E[i,(k,j,l)] := D[(i,j,k),l] i:1, j:2 # does not
+    @cast C[i,(j,k,l)] := D[(i,j,k),l] i in 1:1, j in 1:2 # gets sz... from colonise! too
+    @cast E[i,(k,j,l)] := D[(i,j,k),l] i in 1:1, j in 1:2 # does not
 
     @test size(C) == (1, 2*3*4)
     @test size(E) == (1, 2*3*4)
 
-    B = [rand(2) for i=1:3 ]
+    B = [rand(2) for i=1:3]
     A2 = @cast A[(i,j)] := B[i][j]
     A3 = @cast A[(i,j)] = B[i][j] # for a while this in-place thing returned the wrong shape
     @test size(A) == size(A2) == size(A3) == (6,)
@@ -329,7 +329,7 @@ end
     # This was broken above for a while:
     Bc = [(1:3) .+ 10i for i=1:2]
     @cast f[(b,c)] := Bc[b][c]
-    @cast bc[b,c] := f[(b,c)] b:2 # this bc is a view of f, NB
+    @cast bc[b,c] := f[(b,c)] b in 1:2 # this bc is a view of f, NB
     @cast f[(c,b)] = Bc[b][c]
     @cast bc[b,c] = f[(c,b)]  # thus this copyto! is confusing
     @test_broken bc[1,2] != Bc[1][2] # and in fact leads to duplicates here
@@ -348,7 +348,7 @@ end
 
     ## runtime
 
-    @test_throws DimensionMismatch @cast oo[i,j] := bc[i,j] i:3, assert
+    @test_throws DimensionMismatch @cast oo[i,j] := bc[i,j] i in 1:3, assert
     @test_throws DimensionMismatch @cast cb[i,j] = bc[i,j]  assert
 
 end

--- a/test/shape.jl
+++ b/test/shape.jl
@@ -296,14 +296,14 @@ end
     @cast V[(i,j,k)] := B[i,(k,j)]  k in 1:3, assert # was an error for recursive colon reasons
 
 
-    A = @cast [jk,i] := B[i,jk] # without left-hand name
+    A = @cast _[jk,i] := B[i,jk] # without left-hand name
     @test size(A) == (6,1)
 
-    A = @cast [k,j,i] := B[i,(j,k)] k in 1:3 # without left-hand name
+    A = @cast _[k,j,i] := B[i,(j,k)] k in 1:3 # without left-hand name
     @test size(A) == (3,2,1)
 
-    C = @cast [k][i,j] := B[i,(j,k)]  k in 1:3 # without left-hand name
-    C = @cast [k][i,j] := B[i,(j,k)]  j in 1:2, k in 1:3
+    C = @cast _[k][i,j] := B[i,(j,k)]  k in 1:3 # without left-hand name
+    C = @cast _[k][i,j] := B[i,(j,k)]  j in 1:2, k in 1:3
 
     @test size(C) == (3,)
     @test size(first(C)) == (1,2)

--- a/test/two.jl
+++ b/test/two.jl
@@ -294,10 +294,10 @@ end
     using LoopVectorization
 
     A = rand(4,5)
-    @test exp.(A) ≈ @cast B[i,j] := exp(A[i,j]) avx
+    @test exp.(A) ≈ @cast @avx B[i,j] := exp(A[i,j])
 
-    @test exp.(A') ≈ @cast B[i,j] := exp(A[j,i]) avx
-    @test exp.(A.+1) ≈ @cast B[i,j] := exp(A[i,j]+1) avx
+    @test exp.(A') ≈ @cast @avx B[i,j] := exp(A[j,i])
+    @test exp.(A.+1) ≈ @cast @avx B[i,j] := exp(A[i,j]+1)
 
 end
 end
@@ -323,23 +323,23 @@ end
     bcde = rand(2,3,4,5);
     bcde2 = similar(bcde);
 
-    @cast oo[d,e,b,c] |= bcde[b,c,d,e] strided;
+    @cast @strided oo[d,e,b,c] |= bcde[b,c,d,e];
     @test size(oo) == (4,5,2,3)
     @test oo[1,3,1,3] == bcde[1,3,1,3]
 
     oo[1] = 99
     @test bcde[1] != 99 # copy not a view
 
-    @cast g[(y,e),(b,c),x] := bcde[b,c,(x,y),e]  x in 1:1, strided;
+    @cast @strided g[(y,e),(b,c),x] := bcde[b,c,(x,y),e]  x in 1:1;
     @test size(g) == (20, 6, 1)
-    @cast bcde2[b,c,(x,y),e] = g[(y,e),(b,c),x]  strided;
+    @cast @strided bcde2[b,c,(x,y),e] = g[(y,e),(b,c),x];
     @test all(bcde2 .== bcde) # used to say "fails when using Strided"
 
     # https://github.com/mcabbott/TensorCast.jl/issues/2
     A = rand(3,3); B = rand(3,5);
-    @reduce C[i, j] := sum(l) A[i, l] * B[l, j] strided
+    @reduce @strided C[i, j] := sum(l) A[i, l] * B[l, j]
     @test C ≈ A * B
-    @reduce D[i, j] |= sum(l) A[i, l] * B[l, j] strided
+    @reduce @strided D[i, j] |= sum(l) A[i, l] * B[l, j]
     @test D isa Array
 
 end


### PR DESCRIPTION
This changes the notation to something more obvious:
```julia
using Strided
A = randn(1000,1000);

@cast B[i,j] = (A[i,j] + A[j,i])/2  strided   # old
@cast @strided B[i,j] = (A[i,j] + A[j,i])/2   # new
```
and
```julia
 @cast A[i,j] := (1:12)[(i,j)]  i:3, j:4            # old
 @cast A[i,j] := (1:12)[(i,j)]  i in 1:3, j in 1:4  # new
 
 @reduce A[i] := sum(j:3) (1:12)[i⊗j]  # old, but no warnings
```
and
```julia
@reduce [i] := sum(k) rand(3,3)[i,k]   # old
@reduce _[i] := sum(k) rand(3,3)[i,k]  # new
```
 The old ones will still work, with warnings. 