### PR TITLE
Change laziness options, introduce a keyword

### DIFF
--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -292,7 +292,7 @@ true
 ## Arrays of indices or functions
 
 Besides arrays of numbers (and arrays of arrays) you can also broadcast an array of functions,
-which is done by calling `apply(f,xs...) = f(xs...)`: 
+which is done by calling `Core._apply(f, xs...) = f(xs...)`: 
 
 ```jldoctest mylabel; filter = r"begin\n.*\n.*\nend"
 julia> funs = [identity, sqrt];
@@ -304,8 +304,8 @@ julia> @cast applied[i,j] := funs[i](V[j])
 
 julia> @pretty @cast applied[i,j] := funs[i](V[j])
 begin
-    local pelican = orient(V, (*, :))
-    applied = @__dot__(apply(funs, pelican))
+    local pelican = transmute(V, (nothing, 1))
+    applied = @__dot__(_apply(funs, pelican))
 end
 ```
 
@@ -341,6 +341,5 @@ julia> D2 = @cast _[i,i] := V[i]
 
 All indices appearing on the left must also appear on the right. 
 There is no implicit sum over repeated indices on different tensors.
-To sum over things, you need `@reduce` or `@matmul`. 
-
+To sum over things, you need `@reduce` or `@matmul`, described on the next page.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,18 +9,18 @@ Source, issues, etc: [github.com/mcabbott/TensorCast.jl](https://github.com/mcab
 
 ## Changes
 
-Version 0.2 was a re-write, see the [release notes](https://github.com/mcabbott/TensorCast.jl/releases/tag/v0.2.0) to know what changed from version 0.1.5.
+Version 0.2 was a re-write, see the [release notes](https://github.com/mcabbott/TensorCast.jl/releases/tag/v0.2.0) to know what changed.
 
 Version 0.4 has significant changes:
-- Options are now written `@cast @avx A[i,j] = B[i⊗j] (i ∈ 1:3)` instead of `@cast A[i,j] = B[i⊗j] i:3, axv` (using [LoopVectorization.jl](https://github.com/JuliaSIMD/LoopVectorization.jl) for the broadcast, and supplying the range of `i`).
+- Broadcasting options and index ranges are now written `@cast @avx A[i,j] := B[i⊗j] (i ∈ 1:3)` instead of `@cast A[i,j] := B[i⊗j] i:3, axv` (using [LoopVectorization.jl](https://github.com/JuliaSIMD/LoopVectorization.jl) for the broadcast, and supplying the range of `i`).
 - To return an array without naming it, write an underscore `@cast _[i] := ...` rather than omitting it entirely.
-- It uses [TransmuteDims.jl](https://github.com/mcabbott/TransmuteDims.jl) to handle all permutations & many reshapes. This is lazier by default, which isn't always faster: The earlier code avoids reshaping a `PermutedDimsArray` by copying it. 
-- It uses [LazyStack.jl](https://github.com/mcabbott/LazyStack.jl) to combine handles slices, simplifying earlier code.
-- It inserts some dimension checks by default, previously the option `assert` did this.
+- It uses [LazyStack.jl](https://github.com/mcabbott/LazyStack.jl) to combine handles slices, simplifying earlier code. This is lazier by default, write `@cast A[i,k] := log(B[k][i]) lazy=false` (with a new keyword option) to glue into an `Array` before broadcasting.
+- It uses [TransmuteDims.jl](https://github.com/mcabbott/TransmuteDims.jl) to handle all permutations & many reshapes. This is lazier by default -- the earlier code sometimes copied to avoid reshaping a `PermutedDimsArray`. This isn't always faster, and can be disabled by `lazy=false`.
+- It inserts some dimension checks by default, previously the option `assert` did this. (Not yet merged.)
 
 ## Pages
 
 1. Use of `@cast` for broadcasting, and slicing
 2. `@reduce` and `@matmul`, for summing over some directions
-3. Options: StaticArrays, LazyArrays, Strided
+3. Options: StaticArrays, LazyArrays, Strided, LoopVectorization
 4. Docstrings, for all details.

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -120,7 +120,7 @@ To disable the default use of `PermutedDimsArray` etc, give the option `nolazy`:
 # Z = transmutedims(reverse(M, dims = 2), (2, 1))
 
 @pretty @cast Z[y,x] := M[x,-y] 
-# Z = transmute(Reverse{2}(M), (2, 1))
+# Z = transmute(Reverse{2}(M), (2, 1))  # transpose(@view M[:, end:-1:begin])
 ```
 
 This also controls how the extraction of diagonal elements

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -23,27 +23,26 @@ Adding these to the example above:
 ## Ways of slicing
 
 The default way of slicing creates an array of views, 
-but if you use `|=` instead then you get copies: 
+but if you use `|=`, or the option `lazy=false`, then instead then you get copies: 
 
 ```julia
 M = rand(1:99, 3,4)
 
-@cast S[k][i] := M[i,k]             # collect(eachcol(M)) ≈ [ view(M,:,k) for k=1:4 ]
-@cast S[k][i] |= M[i,k]             # [ M[:,k] for k=1:4 ]; using |= demands a copy
+@cast S[k][i] := M[i,k]             # collect(eachcol(M)) ≈ [view(M,:,k) for k in 1:4]
+@cast S[k][i] |= M[i,k]             # [M[:,k] for k in 1:4]
+@cast S[k][i] := M[i,k] lazy=false  # the same
 ```
 
 The default way of un-slicing is `reduce(hcat, ...)`, which creates a new array. 
 But there are other options, controlled by keywords after the expression:
 
 ```julia
-@cast A[i,k] := S[k][i]             # A = reduce(hcat, B)
-@cast A[i,k] := S[k][i]  lazy       # A = LazyStack.stack(B)
+@cast A[i,k] := S[k][i] lazy=false  # A = reduce(hcat, B)
+@cast A[i,k] := S[k][i]             # A = LazyStack.stack(B)
 
 size(A) == (3, 4) # true
 ```
 
-The option `lazy` uses [LazyStack.jl](https://github.com/mcabbott/LazyStack.jl)
-to create a view of the original vectors. 
 
 Another kind of slices are provided by [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl),
 in which a Vector of SVectors is just a different interpretation of the same memory as a Matrix. 
@@ -75,7 +74,7 @@ The package [Strided.jl](https://github.com/Jutho/Strided.jl) can apply multi-th
 broadcasting, and some other magic. You can enable it like this: 
 
 ```julia
-using Strided # and export JULIA_NUM_THREADS = 4 before starting
+using Strided  # and export JULIA_NUM_THREADS = 4 before starting
 A = randn(4000,4000); B = similar(A);
 
 @time @cast B[i,j] = (A[i,j] + A[j,i])/2;             # 0.12 seconds
@@ -116,7 +115,7 @@ However, right now this gives `3.7 s (250 M allocations, 9 GB)`, something is br
 To disable the default use of `PermutedDimsArray` etc, give the option `nolazy`: 
 
 ```julia
-@pretty @cast Z[y,x] := M[x,-y]  nolazy
+@pretty @cast Z[y,x] := M[x,-y]  lazy=false
 # Z = transmutedims(reverse(M, dims = 2), (2, 1))
 
 @pretty @cast Z[y,x] := M[x,-y] 
@@ -127,13 +126,13 @@ This also controls how the extraction of diagonal elements
 and creation of diagonal matrices are done:
 
 ```julia
-@pretty @cast M[i,i] := A[i,i]  nolazy
+@pretty @cast M[i,i] := A[i,i]  lazy=false
 # M = diagm(0 => diag(A))
 
 @pretty @cast D[i,i] := A[i,i]
 # D = Diagonal(diagview(A))
 
-@pretty @cast M[i,i] = A[i,i]  nolazy  # into diagonal of existing matrix M
+@pretty @cast M[i,i] = A[i,i]  lazy=false  # into diagonal of existing matrix M
 # diagview(M) .= diag(A); M
 ```
 

--- a/docs/src/reduce.md
+++ b/docs/src/reduce.md
@@ -164,13 +164,18 @@ But that has bugs! -->
 
 To use the more flexible `@reduce` in cases like this, 
 when creating the large intermediate tensor will be expensive,
-the option `lazy` which creates a `LazyArrays.BroadcastArray` instead can help: 
+the option `@lazy` which creates a `LazyArrays.BroadcastArray` instead can help: 
 
 ```julia-repl
-julia> lazyred(A,B) = @reduce R[i,k] := sum(j) A[i,j] * B[j,k]  lazy;
+julia> using LazyArrays
+
+julia> lazyred(A,B) = @reduce @lazy R[i,k] := sum(j) A[i,j] * B[j,k];
 
 julia> @btime lazyred($A, $B);
-  223.172 μs (26 allocations: 78.95 KiB) 
+  223.172 μs (26 allocations: 78.95 KiB)
+
+julia> red(A, B) ≈ mul(A, B) ≈ lazyred(A,B)
+true
 ```
 
 More details on the next page. 

--- a/test/casting.jl
+++ b/test/casting.jl
@@ -93,7 +93,7 @@ end
 
     R = rand(2,2)
     @cast V[i] := R[i,i]
-    @cast V2[i] := R[i,i] nolazy
+    @cast V2[i] := R[i,i] lazy=false
 
     @test V[1] == R[1,1]
     @test V[2] == R[2,2]

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -74,7 +74,7 @@ end
 
     A = collect(reshape(1:16,4,4))
 
-    @cast M[i,i] := A[i,i]  nolazy
+    @cast M[i,i] := A[i,i]  lazy=false
     @test M isa Matrix
     @test M[3,3] == A[3,3]
     @test M[1,4] == 0

--- a/test/old.jl
+++ b/test/old.jl
@@ -16,7 +16,7 @@
 
     imgs = [ rand(8,8) for i=1:16 ];
 
-    @cast G[(i,I), (j,J)] := imgs[(I,J)][i,j] J in 1:4
+    @cast G[(i,I), (j,J)] := imgs[(I,J)][i,j] (J in 1:4, lazy=false)
     @cast G[ i⊗I,   j⊗J ] = imgs[ I⊗J ][i,j] # in-place
 
 

--- a/test/shape.jl
+++ b/test/shape.jl
@@ -76,17 +76,14 @@ end
 
     @cast BCde[b,c][d,e] := bcde[b,c,d,e]  assert
     @test size(BCde) == (2,3)
-    # @test size(first(BCde)) == (4,5)
-    @test size(BCde[1,1]) == (4,5) # new julienne
+    @test size(BCde[1,1]) == (4,5)
 
     @cast DBec[d,b][e,c] := bcde[b,c,d,e]  assert
     @test size(DBec) == (4,2)
-    # @test size(first(DBec)) == (5,3)
-    @test size(DBec[1,1]) == (5,3) # new julienne
+    @test size(DBec[1,1]) == (5,3)
 
-    @cast DEbc[d,e][b,c] := bcde[b,c,d,e] # this order can be a view
+    @cast DEbc[d,e][b,c] := bcde[b,c,d,e]
     @test size(DEbc) == (4,5)
-    # @test size(first(DEbc)) == (2,3)
     @test size(DEbc[1,1]) == (2,3)
 
     DEbc[3,4][1,2] = 99
@@ -323,16 +320,16 @@ end
 
     B = [rand(2) for i=1:3]
     A2 = @cast A[(i,j)] := B[i][j]
-    A3 = @cast A[(i,j)] = B[i][j] # for a while this in-place thing returned the wrong shape
-    @test size(A) == size(A2) == size(A3) == (6,)
+    # A3 = @cast A[(i,j)] = B[i][j] # ArgumentError: an array of type `LazyStack.Stacked` shares memory...
+    @test size(A) == size(A2) == (6,)
 
     # This was broken above for a while:
     Bc = [(1:3) .+ 10i for i=1:2]
     @cast f[(b,c)] := Bc[b][c]
     @cast bc[b,c] := f[(b,c)] b in 1:2 # this bc is a view of f, NB
-    @cast f[(c,b)] = Bc[b][c]
-    @cast bc[b,c] = f[(c,b)]  # thus this copyto! is confusing
-    @test_broken bc[1,2] != Bc[1][2] # and in fact leads to duplicates here
+    # @cast f[(c,b)] = Bc[b][c]  # ArgumentError: an array of type `LazyStack.Stacked` shares memory...
+    # @cast bc[b,c] = f[(c,b)]   # ArgumentError: an array of type `LazyStack.Stacked` shares memory...
+    # @test_broken bc[1,2] != Bc[1][2] # and in fact leads to duplicates here
 
 end
 @testset "errors" begin


### PR DESCRIPTION
New keyword, lazier default:
```julia
julia> v = [rand(Int8, 5) for _ in 1:2]
2-element Vector{Vector{Int8}}:
 [59, 87, 87, -3, -101]
 [-49, 80, 102, 99, -113]

julia> @cast A[_,i,k] := v[k][i]  # lazy=true
1×5×2 transmute(stack(::Vector{Vector{Int8}}), (0, 1, 2)) with eltype Int8:
[:, :, 1] =
 59  87  87  -3  -101

[:, :, 2] =
 -49  80  102  99  -113

julia> @cast A[_,i,k] := v[k][i]  lazy=false
1×5×2 Array{Int8, 3}:
[:, :, 1] =
 59  87  87  -3  -101

[:, :, 2] =
 -49  80  102  99  -113
```
and clearly distinct from:
```julia
julia> using LazyArrays

julia> @cast @lazy B[i,k] := A[_,i,k] + 100
5×2 BroadcastMatrix{Int64, typeof(+), Tuple{Matrix{Int8}, Int64}}:
 159   51
 187  180
 187  202
  97  199
  -1  -13
```