### PR TITLE
Handle `OffsetArray`s better, even in `reshape`

### DIFF
--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -27,7 +27,7 @@ module Fast # shield non-macro code from @optlevel 1
     export sliceview, slicecopy, copy_glue, glue!, iscodesorted, countcolons
 
     include("view.jl")
-    export diagview, mul!, rview, star, onetolength
+    export diagview, mul!, rview, star
 
     include("static.jl")
     export static_slice, static_glue

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1065,8 +1065,8 @@ then save an assertion that new size is equal to old.
 """
 function saveonesize(ind, ax, store::NamedTuple)
     if !haskey(store.dict, ind)
-        store.dict[ind] = long
-    elseif store.dict[ind] != long  # no need to save identical expressions
+        store.dict[ind] = ax
+    elseif store.dict[ind] != ax  # no need to save identical expressions
         if isa(ind, Symbol)
             str = "range of index $ind must agree"
             push!(store.assert, :( $(store.dict[ind]) == $ax || throw(ArgumentError($str))) )

--- a/src/static.jl
+++ b/src/static.jl
@@ -18,8 +18,8 @@ or call `static_slice(A, sizes, false)` to omit the reshape.
     end
     IT = SArray{Tuple{tup...}, T, IN, prod(tup)}
     if N-IN>1 && finalshape
-        finalsize = size(A)[1+IN:end]
-        reshape(reinterpret(IT, vec(A)), finalsize)
+        finalaxes = axes(A)[1+IN:end]
+        reshape(reinterpret(IT, vec(A)), finalaxes)
     else
         reinterpret(IT, vec(A)) # always a vector
     end

--- a/src/static.jl
+++ b/src/static.jl
@@ -15,14 +15,16 @@ or call `static_slice(A, sizes, false)` to omit the reshape.
     IN = length(tup)
     for d in 1:IN
         size(A,d) == tup[d] || throw(DimensionMismatch("cannot slice array of size $(size(A)) using Size$tup"))
+        first(axes(A,d)) == 1 || throw(ArgumentError("cannot creat static slices with offset indices"))
     end
     IT = SArray{Tuple{tup...}, T, IN, prod(tup)}
-    if N-IN>1 && finalshape
+    @assert finalshape
+    # if N-IN>1 && finalshape
         finalaxes = axes(A)[1+IN:end]
         reshape(reinterpret(IT, vec(A)), finalaxes)
-    else
-        reinterpret(IT, vec(A)) # always a vector
-    end
+    # else
+    #     reinterpret(IT, vec(A)) # always a vector
+    # end
 end
 
 function static_slice(A::AbstractArray, code::Tuple, finalshape::Bool=true)

--- a/src/static.jl
+++ b/src/static.jl
@@ -11,26 +11,21 @@ but if given code instead it will do what it can.
 Typically produces `reshape(reinterpret(SArray...`; copy this to get `Array{SArray}`,
 or call `static_slice(A, sizes, false)` to omit the reshape.
 """
-@inline function static_slice(A::AbstractArray{T,N}, sizes::Size{tup}, finalshape::Bool=true) where {T,N,tup}
+@inline function static_slice(A::AbstractArray{T,N}, sizes::Size{tup}) where {T,N,tup}
     IN = length(tup)
     for d in 1:IN
         size(A,d) == tup[d] || throw(DimensionMismatch("cannot slice array of size $(size(A)) using Size$tup"))
         first(axes(A,d)) == 1 || throw(ArgumentError("cannot creat static slices with offset indices"))
     end
     IT = SArray{Tuple{tup...}, T, IN, prod(tup)}
-    @assert finalshape
-    # if N-IN>1 && finalshape
-        finalaxes = axes(A)[1+IN:end]
-        reshape(reinterpret(IT, vec(A)), finalaxes)
-    # else
-    #     reinterpret(IT, vec(A)) # always a vector
-    # end
+    finalaxes = axes(A)[1+IN:end]
+    reshape(reinterpret(IT, vec(A)), finalaxes)
 end
 
-function static_slice(A::AbstractArray, code::Tuple, finalshape::Bool=true)
+function static_slice(A::AbstractArray, code::Tuple)
     iscodesorted(code) || error("expected to make slices of left-most dimensions")
     tup = ntuple(d -> size(A,d), countcolons(code))
-    static_slice(A, Size(tup), finalshape)
+    static_slice(A, Size(tup))
 end
 
 """
@@ -39,17 +34,13 @@ end
 Glues the output of `static_slice` back into one array, again with `code = (:,:,...,*,*)`.
 For `MArray` slices, which can't be reinterpreted, this reverts to `red_glue`.
 """
-@inline function static_glue(A::AbstractArray{IT}, finalshape=true) where {IT<:SArray}
-    if finalshape
-        finalsize = (size(IT)..., size(A)...)
-        reshape(reinterpret(eltype(IT), A), finalsize)
-    else
-        reinterpret(eltype(eltype(A)), A)
-    end
+@inline function static_glue(A::AbstractArray{IT}) where {IT<:SArray}
+    finalaxes = (axes(IT)..., axes(A)...)
+    reshape(reinterpret(eltype(IT), A), finalaxes)
 end
 
-function static_glue(A::AbstractArray{IT}, finalshape=true) where {IT<:MArray}
-    stack(A)
+function static_glue(A::AbstractArray{IT}) where {IT<:MArray}
+    LazyStack.stack(A)
 end
 
 # This is now used only by maybestaticsizes...

--- a/src/view.jl
+++ b/src/view.jl
@@ -32,12 +32,3 @@ Used for multiplying axes now, not sizes.
 """
 star(x, y) = Base.OneTo(length(x) * length(y))
 star(x,y,zs...) = star(star(x,y), zs...)
-
-"""
-    onetolength(1:10) == 10
-
-Used to digest options `i in 1:10`, size calculation for reshaping only allows ranges starting at 1 for now.
-"""
-onetolength(ax::Base.OneTo) = length(ax)
-onetolength(ax::AbstractUnitRange) = first(ax) == 1 ? length(ax) : error("ranges have to start at 1, for now")
-onetolength(ax) = error("ranges must be AbstractUnitRange")

--- a/src/view.jl
+++ b/src/view.jl
@@ -28,11 +28,9 @@ mul!(Z::AbstractArray{T,0}, A,B) where {T} = copyto!(Z, A * B)
 """
     star(x,y,...)
 
-Like `*` but intended for multiplying sizes, and understands that `:` is a wildcard.
+Used for multiplying axes now, not sizes.
 """
-star(x,y) = *(x,y)
-star(::Colon,y) = Colon()
-star(x,::Colon) = Colon()
+star(x, y) = Base.OneTo(length(x) * length(y))
 star(x,y,zs...) = star(star(x,y), zs...)
 
 """

--- a/test/four.jl
+++ b/test/four.jl
@@ -87,8 +87,25 @@ end
     @test axes(A) == (0:1, 7:15)
     @test A[1,7] == 71
 
+    # reshape
     @cast B[(i,k),j] := A[i,(j,k)]  k in 1:3
     @test axes(B) === (Base.OneTo(6), Base.OneTo(3))
+
+    # reduction
+    @reduce C[_,j] := sum(i) A[i,j]
+    @test axes(C) == (1:1, 7:15)  # but perhaps the wrong answer!
+
+    # slicing
+    @test axes(@cast _[j] := A[:,j]) == (7:15,)
+    @test axes(@cast _[j][i] := A[i,j]) == (7:15,)
+    @test axes(first(@cast _[j] := A[:,j])) == (0:1,)
+    @test axes(first(@cast _[j][i] := A[i,j])) == (0:1,)
+
+    using StaticArrays
+    @test_broken axes(@cast _[j] := A{:,j}) == (7:15,)  # drops offset from container?
+    @test first(@cast _[j] := A{:,j}) === SVector(70,71)  # ignores offset, to make static slice?
+    @test first(@cast _[j] := A{:2,j}) === SVector(70,71)
+    # note that reinterpret(reshape, SVector{2,Int}, A) gives an error, but it only insists on 1st axis
 end
 
 @testset "tuples" begin

--- a/test/four.jl
+++ b/test/four.jl
@@ -93,7 +93,8 @@ end
 
     # reduction
     @reduce C[_,j] := sum(i) A[i,j]
-    @test axes(C) == (1:1, 7:15)  # but perhaps the wrong answer!
+    @test axes(C) == (1:1, 7:15)
+    @test extrema(C) == (141, 301)  # was reading out of bounds, TransmuteDims bug
 
     # slicing
     @test axes(@cast _[j] := A[:,j]) == (7:15,)
@@ -102,10 +103,12 @@ end
     @test axes(first(@cast _[j][i] := A[i,j])) == (0:1,)
 
     using StaticArrays
-    @test_broken axes(@cast _[j] := A{:,j}) == (7:15,)  # drops offset from container?
-    @test first(@cast _[j] := A{:,j}) === SVector(70,71)  # ignores offset, to make static slice?
-    @test first(@cast _[j] := A{:2,j}) === SVector(70,71)
-    # note that reinterpret(reshape, SVector{2,Int}, A) gives an error, but it only insists on 1st axis
+    @test_throws Exception @cast _[j] := A{:,j}  # similar error to reinterpret(reshape, SVector{2,Int}, A)
+    @cast D[i,j] := i+10j  (i in 1:3, j in 7:15)
+    @test axes(@cast _[j] := D{:,j}) == (7:15,)
+    @test first(@cast _[j] := D{:,j}) === SVector(71, 72, 73)
+    @test first(@cast _[j] := D{:3,j}) === SVector(71, 72, 73)
+    @test_throws Exception @cast _[j] := D{:2,j}  # wrong size
 end
 
 @testset "tuples" begin

--- a/test/four.jl
+++ b/test/four.jl
@@ -81,6 +81,16 @@ end
     @test E ≈ sum((1:2) ./ (1:4)')
 end
 
+@testset "offset handling" begin
+    using OffsetArrays
+    @cast A[i,j] := i+10j  (i in 0:1, j in 7:15)
+    @test axes(A) == (0:1, 7:15)
+    @test A[1,7] == 71
+
+    @cast B[(i,k),j] := A[i,(j,k)]  k in 1:3
+    @test axes(B) === (Base.OneTo(6), Base.OneTo(3))
+end
+
 @testset "tuples" begin
     x = rand(3, 5)
     @cast vi[j,k] := findmax(x[:, k])[j]

--- a/test/shape.jl
+++ b/test/shape.jl
@@ -1,5 +1,3 @@
-usingstatic =   isdefined(TensorCast, :StaticArray)
-
 @testset "scope" begin
 
     bc = rand(2,3)


### PR DESCRIPTION
This replaces things like `reshape(A, (3, :, 5))` with things like `reshape(A, (1:3, 1:4, 1:5))`, by keeping track of the axes all the way through, instead of the sizes. 

This reshape method doesn't allow colons, but #38 changes index range inference never to return a colon (for other reasons) so this PR is built on that one.

And #34 changed how index ranges are specified from weird `i:3` to `i in 1:3`, which can now generalise to `i in 2:4` etc. So things like this should now work:

```julia
julia> M = reshape(1:12, 3,4)
3×4 reshape(::UnitRange{Int64}, 3, 4) with eltype Int64:
 1  4  7  10
 2  5  8  11
 3  6  9  12

julia> @reduce _[i,k] := sum(j) M[i,(j,k)]  k in 2:3
3×2 transmute(OffsetArray(::Array{Int64, 3}, 1:3, 1:1, 2:3), (1, 3)) with eltype Int64 with indices 1:3×2:3:
 5  17
 7  19
 9  21
```
~~The final `transmute` is performing `dropdims`, which it would normally do by reshaping the `Array`, but it blocked here. It should be made smarter.~~ Reverted to `dropdims`. But other reshapes aren't so pretty, still:
```julia
julia> @reduce _[i,k] := sum(j) M[i,(j,k)]  k in 2:3
3×2 OffsetArray(::Matrix{Int64}, 1:3, 2:3) with eltype Int64 with indices 1:3×2:3:
 5  17
 7  19
 9  21

julia> @reduce _[i,k,_] := sum(j) M[i,(j,k)]  k in 2:3
3×2×1 transmute(OffsetArray(::Matrix{Int64}, 1:3, 2:3), (1, 2, 0)) with eltype Int64 with indices OffsetArrays.IdOffsetRange(1:3)×OffsetArrays.IdOffsetRange(2:3)×Base.OneTo(1):
[:, :, 1] =
 5  17
 7  19
 9  21
```