### PR TITLE
Broadcasting a splat

### DIFF
--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -345,6 +345,23 @@ true
 ```
 
 This one can also be done as `reinterpret(reshape, Tri{Int64}, M)`. 
+But what would be smarter in the general case is to do one splat, not many:
+
+```julia-repl
+julia> Tri.(eachrow(M)...)
+4-element Vector{Tri{Int64}}:
+ Tri{Int64}(1, 2, 3)
+ Tri{Int64}(4, 5, 6)
+ Tri{Int64}(7, 8, 9)
+ Tri{Int64}(10, 11, 12)
+
+julia> @btime Base.splat(tuple).(eachcol(m))  setup=(m=rand(4,100));
+  38.041 μs (1411 allocations: 48.33 KiB)
+
+julia> @btime tuple.(eachrow(m)...)  setup=(m=rand(4,100));
+  824.256 ns (12 allocations: 4.06 KiB)
+```
+
 ## Arrays of functions
 
 Besides arrays of numbers (and arrays of arrays) you can also broadcast an array of functions,

--- a/test/four.jl
+++ b/test/four.jl
@@ -147,7 +147,6 @@ end
     @cast z2[j,i] := tuple(i, j, y[i,j,:]...)
     @test z2[4,5] == (5, 4, y[5,4,:]...)
 
-
     struct Quad x; y; z; t; end
     @cast z3[i,j] := Quad(y[i,:,j]...)
     @test z3[2,3] == Quad(y[2,:,3]...)

--- a/test/four.jl
+++ b/test/four.jl
@@ -144,8 +144,8 @@ end
     @test z′[3,4] == Tuple(y[4,3,:])
 
     # with other arguments, they have to come first at the moment:
-    @test_skip @cast z2[j,i] := tuple(i, j, y[i,j,:]...)
-    # @test z2[4,5] == (5, 4, y[5,4,:]...)
+    @cast z2[j,i] := tuple(i, j, y[i,j,:]...)
+    @test z2[4,5] == (5, 4, y[5,4,:]...)
 
 
     struct Quad x; y; z; t; end

--- a/test/four.jl
+++ b/test/four.jl
@@ -144,8 +144,9 @@ end
     @test z′[3,4] == Tuple(y[4,3,:])
 
     # with other arguments, they have to come first at the moment:
-    @cast z2[j,i] := tuple(i, j, y[i,j,:]...)
-    @test z2[4,5] == (5, 4, y[5,4,:]...)
+    @test_skip @cast z2[j,i] := tuple(i, j, y[i,j,:]...)
+    # @test z2[4,5] == (5, 4, y[5,4,:]...)
+
 
     struct Quad x; y; z; t; end
     @cast z3[i,j] := Quad(y[i,:,j]...)


### PR DESCRIPTION
On master the following syntax is understood:
```
julia> using TensorCast, ImageCore

julia> mat = rand(1:10, 4, 3) ./ 10;

julia> @cast _[k] := RGB(mat[k,:]...)
4-element Array{RGB{Float64},1} with eltype RGB{Float64}:
 RGB{Float64}(0.8,0.7,0.7)
 RGB{Float64}(0.5,0.7,0.5)
 RGB{Float64}(0.9,0.7,0.2)
 RGB{Float64}(0.7,0.2,1.0)
```
But this is done quite inefficiently, by literally performing the splat for every slice. It would be better to re-write it to slice the other way, splat once, and then broadcast:
 ```
 julia> @btime Base.splat(RGB).(eachrow(m))  setup=(m=rand(100,3));
  22.541 μs (1122 allocations: 38.89 KiB)

julia> @btime RGB.(eachcol(m)...)  setup=(m=rand(100,3));
  421.905 ns (10 allocations: 3.12 KiB)
```
Can this be done in general?