### PR TITLE
Allow `repeat`-like patterns

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,10 @@
 
 using Documenter
-using TensorCast
+using TensorCast, OffsetArrays
 
 makedocs(
     sitename = "TensorCast",
-    modules = [TensorCast],
+    modules = [TensorCast, OffsetArrays],
     pages = [
         "Home" => "index.md",
         "Basics" => "basics.md",

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -83,7 +83,7 @@ Combining this with slicing from `M[:,j]` is a convenient way to perform `mapsli
 
 ```jldoctest mylabel
 julia> @cast C[i,j] := cumsum(M[:,j])[i]
-3×4 stack(::Vector{Vector{Int64}}) with eltype Int64:
+3×4 lazystack(::Vector{Vector{Int64}}) with eltype Int64:
  1   4   7  10
  3   9  15  21
  6  15  24  33
@@ -205,28 +205,23 @@ as `size(A)` is known:
 julia> @cast A[i,j] = 10 * collect(1:12)[i⊗j];
 ```
 
+## Repeating
+
 If the right hand side is independent of an index, then the same result is repeated. 
 The range of the index must still be known:
 
 ```jldoctest mylabel
 julia> @cast R[r,(n,c)] := M[r,c]^2  (n in 1:3)
-ERROR: LoadError: index n appears only on the left
-    @cast R[r, (n, c)] := M[r, c] ^ 2  n in 1:3
-    @ Main none:1
-Stacktrace:
- [1] checkallseen(canon::Vector{Any}, store::NamedTuple{(:dict, :assert, :mustassert, :seen, :need, :top, :main), Tuple{Dict{Any, Any}, Vector{Any}, Vector{Any}, Vector{Any}, Vector{Any}, Vector{Any}, Vector{Any}}}, call::TensorCast.CallInfo)
-   @ TensorCast ~/.julia/dev/TensorCast/src/macro.jl:1466
- [2] _macro(exone::Expr, extwo::Expr, exthree::Nothing; call::TensorCast.CallInfo, dict::Dict{Any, Any})
-   @ TensorCast ~/.julia/dev/TensorCast/src/macro.jl:199
- [3] var"@cast"(__source__::LineNumberNode, __module__::Module, exs::Vararg{Any})
-   @ TensorCast ~/.julia/dev/TensorCast/src/macro.jl:74
-in expression starting at none:1
+3×12 Matrix{Int64}:
+ 1  1  1  16  16  16  49  49  49  100  100  100
+ 4  4  4  25  25  25  64  64  64  121  121  121
+ 9  9  9  36  36  36  81  81  81  144  144  144
 
 julia> R == repeat(M .^ 2, inner=(1,3))
 true
 
-julia> @cast R[r,(c,n)] = M[r,c]  # repeat(M, outer=(1,3)), uses size(R)
-3×12 Array{Int64,2}:
+julia> @cast similar(R)[r,(c,n)] = M[r,c]  # repeat(M, outer=(1,3)), uses size(R)
+3×12 Matrix{Int64}:
  1  4  7  10  1  4  7  10  1  4  7  10
  2  5  8  11  2  5  8  11  2  5  8  11
  3  6  9  12  3  6  9  12  3  6  9  12

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,6 +23,7 @@ New features in 0.4:
 - Indices can appear ouside of indexing: `@cast A[i,j] = i+j` translates to `A .= axes(A,1) .+ axes(A,2)'`
 - The ternary operator `? :` can appear on the right, and will be broadcast correctly.
 - All operations should now support [OffsetArrays.jl](https://github.com/JuliaArrays/OffsetArrays.jl).
+- You can `repeat` by broadcasting over indices not appearing on the right, such as `@cast r[i,(k,j)] = m[i,j]`
 
 ## Pages
 

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -22,12 +22,12 @@ M = rand(1:99, 3,4)
 @cast S[k][i] := M[i,k] lazy=false  # the same
 ```
 
-The default way of un-slicing is `reduce(hcat, ...)`, which creates a new array. 
-But there are other options, controlled by keywords after the expression:
+The default way of un-slicing uses [LazyStack.jl](https://github.com/mcabbott/LazyStack.jl) to create a view.
+The keyword `lazy=false` after the expression will turn this off, to make a solid array using Base's code:
 
 ```julia
-@cast A[i,k] := S[k][i] lazy=false  # A = reduce(hcat, B)
 @cast A[i,k] := S[k][i]             # A = LazyStack.stack(B)
+@cast A[i,k] := S[k][i] lazy=false  # A = reduce(hcat, B)
 
 size(A) == (3, 4) # true
 ```

--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -32,7 +32,7 @@ module Fast # shield non-macro code from @optlevel 1
     export sliceview, slicecopy, copy_glue, glue!, iscodesorted, countcolons
 
     include("view.jl")
-    export diagview, mul!, rview, star
+    export diagview, mul!, rview, star, onlyfirst
 
     include("static.jl")
     export static_slice, static_glue

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1600,11 +1600,8 @@ function inplaceoutput(ex, canon, parsed, store::NamedTuple, call::CallInfo)
         newleft = standardise(parsed.left, store, call)
         @capture(newleft, zed_[ijk__]) || throw(MacroError("failed to parse LHS correctly, $(parsed.left) -> $newleft"))
 
-        if !(zed isa Symbol) # then standardise did something!
+        if newleft != parsed.left  # then standardise did something!
             push!(call.flags, :showfinal)
-            Zsym = gensym(:reverse)
-            push!(out, :( local $Zsym = $zed ) )
-            zed = Zsym
         end
     end
 
@@ -1629,7 +1626,12 @@ function inplaceoutput(ex, canon, parsed, store::NamedTuple, call::CallInfo)
     end
 
     if :showfinal in call.flags
-        push!(out, parsed.name)
+        A = parsed.name
+        if A isa Symbol || @capture(A, AA_.ff_)
+        else
+            A = Symbol(A,"_val") # exact same symbol is used by standardise()
+        end
+        push!(out, A)
     end
 
     return out

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -187,6 +187,7 @@ function _macro(exone, extwo=nothing, exthree=nothing; call::CallInfo=CallInfo()
 
     # Third pass to standardise & then glue, postwalk sees A[i] before A[i][j]
     right3 = MacroTools.postwalk(x -> standardglue(x, canon, store, call), right2)
+    right3 = checkallseen(right3, canon, store, call)
 
     if !(:matmul in call.flags)
         # Then finally broadcasting if necc (or just permutedims etc. if not):
@@ -195,8 +196,6 @@ function _macro(exone, extwo=nothing, exthree=nothing; call::CallInfo=CallInfo()
         # or, for matmul, can I change just this? outputinplace is also going to need changing.
         right4 = matmultarget(right3, canon, parsed, store, call)
     end
-
-    checkallseen(canon, store, call) # this must be run before inplaceoutput()
 
     # Return to LHS, build up what it requested:
     if :inplace in call.flags
@@ -1345,6 +1344,25 @@ end
 # end
 
 """
+    checkallseen(rhs, ...)
+
+Now not just a check, but also inserts trivial broadcasting, if needed, 
+over indices omitted from the rhs.
+"""
+function checkallseen(ex, canon, store, call)
+    right = setdiff(store.seen, canon)
+    length(right) > 0 && throw(MacroError("index $(right[1]) appears only on the right", call))
+    left = setdiff(canon, unique!(store.seen))
+    # length(left) > 0 && throw(MacroError("index $(left[1]) appears only on the left", call))
+    if isempty(left)
+        ex
+    else
+        fake = map(i -> recursemacro(i, canon, store, call), left)
+        :( TensorCast.onlyfirst($ex, $(fake...)) )
+    end
+end
+
+"""
     needview!([:, 3, A])   # true, need view(A, :,3,:)
     needview!([:, :_, :])  # false, can use rview(A, :,1,:)
 
@@ -1467,14 +1485,6 @@ function checknorepeats(flat, call=nothing, msg=nothing)
     end
 end
 
-function checkallseen(canon, store, call)
-    left = setdiff(canon, unique!(store.seen))
-    length(left) > 0 && throw(MacroError("index $(left[1]) appears only on the left", call))
-    right = setdiff(store.seen, canon)
-    length(right) > 0 && throw(MacroError("index $(right[1]) appears only on the right", call))
-end
-
-# this may never be necessary with checkallseen?
 function findcheck(i::Symbol, flat::Vector, call=nothing, msg=nothing)
     msg == nothing && (msg = " in " * string(:( [$(flat...)] )))
     res = findfirst(isequal(i), flat)

--- a/src/view.jl
+++ b/src/view.jl
@@ -28,7 +28,15 @@ mul!(Z::AbstractArray{T,0}, A,B) where {T} = copyto!(Z, A * B)
 """
     star(x,y,...)
 
-Used for multiplying axes now, not sizes.
+Used for multiplying axes now, always producing a `OneTo` whose length
+is the product of the given ranges.
 """
 star(x, y) = Base.OneTo(length(x) * length(y))
 star(x,y,zs...) = star(star(x,y), zs...)
+
+"""
+    onlyfirst(x, ys...) = x
+
+Used with arguments which are there just to set the shape of broadcasting.
+"""
+onlyfirst(x, ys...) = x

--- a/test/four.jl
+++ b/test/four.jl
@@ -183,8 +183,9 @@ end
     @test y == @cast _[i,j,k] := tuple(y[i,:,k]...)[j]
 end
 
+using TensorCast: MacroError, _macro, CallInfo
 @testset "bugs" begin
     # scatter not handled, previously ignored -- https://github.com/mcabbott/TensorCast.jl/issues/49
-    @test_throws TensorCast.MacroError @pretty @reduce v[ixs[j]] := mean(i) vs[i][j]
-    @test_throws TensorCast.MacroError @pretty @cast v[i][ixs[j]] := vs[j][i]
+    @test_throws MacroError _macro(:(  v[ixs[j]] := mean(i) ),:(  vs[i][j] ), call=CallInfo(:reduce))
+    @test_throws MacroError _macro(:(  v[i][ixs[j]] := vs[j][i] ), call=CallInfo())
 end

--- a/test/four.jl
+++ b/test/four.jl
@@ -114,6 +114,10 @@ end
     @cast E[(j,i),k] := A[i,j]^2  (k in 10:11)  # RHS indep k
     @test E[:,11] == vec(A') .^ 2
 
+    # dropdims
+    @cast F[i,k,j] := A[i,j]  k in 5:5  # a trivial dimension not indexed from 1
+    @test A == @cast _[i,j] := F[i,_,j]
+
     # reduction
     @reduce C[_,j] := sum(i) A[i,j]
     @test axes(C) == (1:1, 7:15)


### PR DESCRIPTION
Apparently I wrote this and never merged the branch. But did add it to the docs, and was confused why they failed in #46 ... that example now looks as follows:
```julia
julia> M = Array(reshape(1:12, 3,4));

julia> @cast R[r,(n,c)] := M[r,c]^2  (n in 1:3)
3×12 Matrix{Int64}:
 1  1  1  16  16  16  49  49  49  100  100  100
 4  4  4  25  25  25  64  64  64  121  121  121
 9  9  9  36  36  36  81  81  81  144  144  144

julia> @pretty @cast R[r,(n,c)] := M[r,c]^2  (n in 1:3)
begin
    @boundscheck ndims(M) == 2 || throw(ArgumentError("expected a 2-tensor M[r, c]"))
    local (ax_c, ax_n, ax_r) = (axes(M, 2), OneTo(3), axes(M, 1))
    local spider = transmute(M, Val((1, nothing, 2)))
    local tapir = transmute(ax_n, Val((nothing, 1)))
    R = reshape(@__dot__(onlyfirst(spider ^ 2, tapir)), (ax_r, star(ax_n, ax_c)))
end

julia> R = randn(3, 3*4);

julia> @cast R[r,(n,c)] = M[r,c]^2  (n in 1:3)  # worked before, now returns R
3×12 Matrix{Float64}:
 1.0  1.0  1.0  16.0  16.0  16.0  49.0  49.0  49.0  100.0  100.0  100.0
 4.0  4.0  4.0  25.0  25.0  25.0  64.0  64.0  64.0  121.0  121.0  121.0
 9.0  9.0  9.0  36.0  36.0  36.0  81.0  81.0  81.0  144.0  144.0  144.0
```

Closes #46. Also closes #48:

```julia
julia> X = randn(1000, 1000);

julia> Y = repeat(X, inner=(2,2));

julia> Y2 = similar(Y);

julia> @cast Y2[(a,b), (c,d)] = X[b, d];

julia> Y2 == Y
true

julia> @cast Y3[(a,b), (c,d)] := X[b, d]  (a in 1:2, c in 1:2);

julia> Y3 == Y
true

julia> @pretty @cast Y3[(a,b), (c,d)] := X[b, d]  (a in 1:2, c in 1:2)
begin
    @boundscheck ndims(X) == 2 || throw(ArgumentError("expected a 2-tensor X[b, d]"))
    local (ax_a, ax_b, ax_c, ax_d) = (OneTo(2), axes(X, 1), OneTo(2), axes(X, 2))
    local spider = transmute(X, Val((nothing, 1, nothing, 2)))
    local tapir = transmute(ax_c, Val((nothing, nothing, 1)))
    Y3 = reshape(@__dot__(onlyfirst(spider, ax_a, tapir)), (star(ax_a, ax_b), star(ax_c, ax_d)))
end
```
Test failure on 1.6 is due to new tests added in  https://github.com/mcabbott/TensorCast.jl/commit/c1fe3b11dd3c251785896dbc3956300173ed9906 which I only checked on 1.9.

Slightly alarmed that doc tests don't fail, but the docs do need fixing.