### PR TITLE
Updated compat versions and Fast tweak for tests to all work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,8 +20,7 @@ LazyArrays = "0.21, 0.22"
 LazyStack = "0.1.0"
 MacroTools = "0.5"
 StaticArrays = "1.3"
-Strided = "1.1"
-TransmuteDims = "0.1.13"
+TransmuteDims = "0.1.15"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -14,14 +14,14 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TransmuteDims = "24ddb15e-299a-5cc3-8414-dbddc482d9ca"
 
 [compat]
-ChainRulesCore = "1.11"
-Compat = "3.46, 4.2"  # for stack
-LazyArrays = "0.21, 0.22"
-LazyStack = "0.1.0"
+ChainRulesCore = "1.16"
+Compat = "3.46, 4.2, 4.7"  # for stack
+LazyArrays = "1.1"
+LazyStack = "0.1.1"
 MacroTools = "0.5"
-StaticArrays = "1.3"
+StaticArrays = "1.5"
 TransmuteDims = "0.1.15"
-julia = "1.6"
+julia = "1"
 
 [extras]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -25,7 +25,7 @@ include("macro.jl")
 include("pretty.jl")
 
 module Fast # shield non-macro code from @optlevel 1
-    using ..TensorCast: pretty
+    using TensorCast: pretty
     using LinearAlgebra, StaticArrays
 
     include("slice.jl")


### PR DESCRIPTION
Updated versions and changed the `TensorCast` import in the `Fast` module so that the tests all work. I don't know if correct to do that. `TransmuteDims` is set to the current version 0.1.15 without the Strided v2 `UnsafeStridedView` changes in the PR Update Strided dep to v2 #41.