### PR TITLE
allow LazyArrays 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ TransmuteDims = "24ddb15e-299a-5cc3-8414-dbddc482d9ca"
 [compat]
 ChainRulesCore = "1.11"
 Compat = "3.46, 4.2"  # for stack
-LazyArrays = "0.21, 0.22"
+LazyArrays = "0.21, 0.22, 1"
 LazyStack = "0.1.0"
 MacroTools = "0.5"
 StaticArrays = "1.3"


### PR DESCRIPTION
Without this, the package gets an old version of ArrayLayouts which errors on testing 1.11:

```
Failed to precompile LazyArrays [5078a376-72f3-5289-bfd5-ec5146d43c02] to "/home/pkgeval/.julia/compiled/v1.11/LazyArrays/jl_XdUB8l".
ERROR: LoadError: too many parameters for type AbstractTriangular
Stacktrace:
 [1] top-level scope
   @ ~/.julia/packages/ArrayLayouts/4IG3b/src/memorylayout.jl:712
 [2] include(mod::Module, _path::String)
   @ Base ./Base.jl:558
 [3] include(x::String)
   @ ArrayLayouts ~/.julia/packages/ArrayLayouts/4IG3b/src/ArrayLayouts.jl:1
 [4] top-level scope
   @ ~/.julia/packages/ArrayLayouts/4IG3b/src/ArrayLayouts.jl:103
 [5] include
   @ ./Base.jl:558 [inlined]
 [6] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::String)
   @ Base ./loading.jl:2721
 [7] top-level scope
   @ stdin:4
in expression starting at /home/pkgeval/.julia/packages/ArrayLayouts/4IG3b/src/memorylayout.jl:712
in expression starting at /home/pkgeval/.julia/packages/ArrayLayouts/4IG3b/src/ArrayLayouts.jl:1
in expression starting at stdin:4
```

1.11 tests passed locally for me with this:

```
new in 0.4    |   61       1     62  9.6s
Test Summary: | Pass  Total  Time
einops comp   |   18     18  3.3s
     Testing TensorCast tests passed 

julia> VERSION
v"1.11.0-beta1"
```