### PR TITLE
Allow LazyArray 2, and drop Julia 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - '1' # '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,26 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
-          - '1' # '1' will automatically expand to the latest stable 1.x release of Julia.
+          - '1'
           - 'nightly'
+          - "1.10"
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
+        continue-on-error: ${{ matrix.julia-version == 'nightly' }}
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
+        continue-on-error: ${{ matrix.julia-version == 'nightly' }}
         env:
           cache-name: cache-artifacts
         with:
@@ -40,8 +41,14 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
+        continue-on-error: ${{ matrix.julia-version == 'nightly' }}
       - uses: julia-actions/julia-runtest@v1
+        continue-on-error: ${{ matrix.julia-version == 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        continue-on-error: ${{ matrix.julia-version == 'nightly' }}
+      - uses: codecov/codecov-action@v3
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
         with:
           file: lcov.info
+        continue-on-error: ${{ matrix.julia-version == 'nightly' }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorCast"
 uuid = "02d47bb6-7ce6-556a-be16-bb1710789e2b"
 authors = ["Michael Abbott"]
-version = "0.4.8"
+version = "0.4.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -16,13 +16,13 @@ TransmuteDims = "24ddb15e-299a-5cc3-8414-dbddc482d9ca"
 [compat]
 ChainRulesCore = "1.11"
 Compat = "3.46, 4.2"  # for stack
-LazyArrays = "0.21, 0.22, 1"
+LazyArrays = "1, 2"
 LazyStack = "0.1.0"
 MacroTools = "0.5"
 StaticArrays = "1.3"
 Strided = "1.1, 2"
 TransmuteDims = "0.1.13"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -40,6 +40,7 @@ module Fast # shield non-macro code from @optlevel 1
 end
 using .Fast
 const mul! = Fast.mul!
+const diagview = Fast.diagview  # trying to solve error with Hint: a global variable of this name also exists in LinearAlgebra.
 
 include("warm.jl") # saves 3s in my test
 

--- a/src/TensorCast.jl
+++ b/src/TensorCast.jl
@@ -40,7 +40,6 @@ module Fast # shield non-macro code from @optlevel 1
 end
 using .Fast
 const mul! = Fast.mul!
-const diagview = Fast.diagview  # trying to solve error with Hint: a global variable of this name also exists in LinearAlgebra.
 
 include("warm.jl") # saves 3s in my test
 

--- a/src/view.jl
+++ b/src/view.jl
@@ -1,4 +1,4 @@
-
+if !isdefined(LinearAlgebra, :diagview)  # trying to solve error on 1.12
 """
     diagview(M) = view(M, diagind(M))
 
@@ -7,6 +7,7 @@ Like `diag(M)` but makes a view.
 diagview(A::AbstractMatrix) = view(A, diagind(A))
 
 diagview(A::LinearAlgebra.Diagonal) = A.diag
+end
 
 """
     rvec(x) = [x]

--- a/test/two.jl
+++ b/test/two.jl
@@ -243,9 +243,9 @@ end
     @test mat[1,2] != 99
 
 end
-@testset "@avx" begin
+VERSION < v"1.12-" && @testset "@avx" begin
 
-    using LoopVectorization
+    using LoopVectorization  # supports 1.10 and maybe 1.11, likely to be broken on master
 
     A = rand(4,5)
     @test exp.(A) ≈ @cast @avx B[i,j] := exp(A[i,j])


### PR DESCRIPTION
Tests pass locally. Change log here: https://github.com/JuliaArrays/LazyArrays.jl/releases/tag/v2.0.0

Documentation to be solved another day.

Some version updates will still be blocked until https://github.com/mcabbott/TransmuteDims.jl/pull/44 
